### PR TITLE
chore: update GitHub Actions to v6 and add project badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # entdomain
 
+[![CI](https://github.com/danhtran94/entdomain/actions/workflows/ci.yml/badge.svg)](https://github.com/danhtran94/entdomain/actions/workflows/ci.yml)
+[![Security](https://github.com/danhtran94/entdomain/actions/workflows/security.yml/badge.svg)](https://github.com/danhtran94/entdomain/actions/workflows/security.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/danhtran94/entdomain/badge)](https://scorecard.dev/viewer/?uri=github.com/danhtran94/entdomain)
+[![Go Reference](https://pkg.go.dev/badge/github.com/danhtran94/entdomain.svg)](https://pkg.go.dev/github.com/danhtran94/entdomain)
+[![Go Report Card](https://goreportcard.com/badge/github.com/danhtran94/entdomain)](https://goreportcard.com/report/github.com/danhtran94/entdomain)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
 An [ent](https://entgo.io/ent) extension that generates a pure Go domain layer from your ent schema — with zero ORM dependency in the domain package.
 
 ## Overview


### PR DESCRIPTION
This pull request makes two main improvements: it updates the CI workflow to use the latest versions of key GitHub Actions, and it enhances the project documentation by adding several status badges to the `README.md`.

Documentation improvements:

* Added multiple badges to the top of the `README.md` to display CI status, security checks, OpenSSF Scorecard, Go Reference, Go Report Card, and license information, making project status and quality more visible to users.

CI workflow updates:

* Updated the `ci.yml` workflow to use the latest major versions of `actions/checkout` (v6) and `actions/setup-go` (v6), ensuring compatibility and access to the latest features and security updates.Updated actions/checkout and actions/setup-go to v6 versions for improved reliability and security. Added CI, security, scorecard, Go reference, Go Report Card, and license badges to README.md to provide better project visibility and status information.