### PR TITLE
chore(renovate): update schedule to Asia/Ho_Chi_Minh timezone

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
       "automerge": false
     }
   ],
-  "schedule": ["before 9am on Monday"]
+  "timezone": "Asia/Ho_Chi_Minh",
+  "schedule": ["after 0:00 before 1:00"]
 }


### PR DESCRIPTION
Change Renovate's schedule to use Asia/Ho_Chi_Minh timezone and adjust schedule to run after 0:00 before 1:00
instead of before 9am on Monday.