### PR TITLE
feat: add dependency label for Renovate and CodeRabbit integration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,11 +9,5 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    # CodeRabbit skips bot-authored PRs by default (hardcoded server-side).
-    # The supported override is label-based: any PR carrying one of these
-    # labels gets auto-reviewed regardless of author. Renovate is configured
-    # (renovate.json) to tag its PRs with `dependencies`.
-    labels:
-      - dependencies
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,5 +9,11 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # CodeRabbit skips bot-authored PRs by default (hardcoded server-side).
+    # The supported override is label-based: any PR carrying one of these
+    # labels gets auto-reviewed regardless of author. Renovate is configured
+    # (renovate.json) to tag its PRs with `dependencies`.
+    labels:
+      - dependencies
 chat:
   auto_reply: true

--- a/.github/workflows/coderabbit-bot-prs.yml
+++ b/.github/workflows/coderabbit-bot-prs.yml
@@ -1,0 +1,32 @@
+name: Trigger CodeRabbit review on bot PRs
+
+# CodeRabbit skips bot-authored PRs (renovate[bot], dependabot[bot]) by default;
+# the skip is hardcoded server-side and not overridable via .coderabbit.yaml.
+# This workflow posts a `@coderabbitai review` comment on bot PRs so they get
+# reviewed anyway — important for dependency updates where supply-chain risk
+# benefits from a second pair of eyes.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  trigger:
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post review trigger comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@coderabbitai review'
+            });

--- a/.github/workflows/coderabbit-bot-prs.yml
+++ b/.github/workflows/coderabbit-bot-prs.yml
@@ -20,13 +20,32 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Post review trigger comment
+      - name: Post review trigger comment (idempotent)
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '@coderabbitai review'
+            // Guard against duplicate pings when reopen / ready_for_review fires
+            // on a PR we've already commented on. Paginate through existing
+            // comments and skip if our bot already posted the marker.
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const body = '@coderabbitai review';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
             });
+
+            const alreadyPosted = comments.some(
+              (c) => c.user?.login === 'github-actions[bot]' && c.body?.trim() === body
+            );
+
+            if (alreadyPosted) {
+              core.info('Skipping: review trigger already posted on this PR.');
+              return;
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "postUpdateOptions": ["gomodTidy"],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Added labels configuration to Renovate bot to tag dependency updates with "dependencies" label, and configured CodeRabbit to auto-review PRs with this label to bypass default bot PR filtering behavior. This ensures dependency updates are properly reviewed while maintaining automated workflow for non-bot PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that triggers a review ping on pull requests opened by dependency bots, ensuring maintainers are notified.
  * Workflow avoids duplicate pings by detecting an existing marker comment before posting.
  * Added a top-level configuration to label dependency-related pull requests for improved organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->