### PR TITLE
fix: restore canonical Apache-2.0 APPENDIX for pkg.go.dev detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -162,4 +162,29 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-   10. End of Terms and Conditions
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed line" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary

pkg.go.dev currently reports **License: UNKNOWN** for this module and suppresses the API documentation with "Documentation not displayed due to license restrictions."

Root cause: our `LICENSE` file was missing the canonical **APPENDIX** section that follows "END OF TERMS AND CONDITIONS" in the official Apache-2.0 text. pkg.go.dev uses [`google/licensecheck`](https://github.com/google/licensecheck) to fuzzy-match against a license corpus; the APPENDIX is a significant fraction of the expected text, so its absence drops the match score below threshold.

## Changes

- Append the canonical APPENDIX block (the "how to apply" boilerplate that's standard in every Apache-2.0-licensed project).
- Fix the section break: our `10. End of Terms and Conditions` → the canonical `END OF TERMS AND CONDITIONS` (all caps, unnumbered). This also improves match score.

No substantive license change — this is the same Apache-2.0 license, restored to its canonical form.

## Post-merge

Tag a patch release (`v1.2.1` is the natural next step) so pkg.go.dev picks up the fix. pkg.go.dev re-indexes within a few minutes of the new tag being pushed.

```sh
git tag -a v1.2.1 -m "fix: restore canonical Apache-2.0 LICENSE for pkg.go.dev detection"
git push origin v1.2.1
```

## Verification

- ✅ Diff against the canonical Apache-2.0 text (https://www.apache.org/licenses/LICENSE-2.0.txt): only whitespace/leading-indent differences remain, consistent with projects like Kubernetes, Docker, etc.
- ⏳ After merge + tag, refresh https://pkg.go.dev/github.com/danhtran94/entdomain — license should show as Apache-2.0 and documentation should render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced license document formatting by updating the terms conclusion section with uppercase styling for improved readability.
  * Added Apache 2.0 appendix section with standard application instructions and copyright attribution templates for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->