### PR TITLE
feat(fiql): support UUID fields in FIQL queries (ENTD-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ invalid time value "not-a-time" for field "created_at": ...
 
 ### Known Limitations
 
-- **UUID fields with custom `GoType(...)`** — only the standard `github.com/google/uuid.UUID` type is wired. UUID fields backed by an alternative type via `GoType(...)` fall back to silent-skip.
+- **UUID fields with custom `GoType(...)`** — only the canonical `github.com/google/uuid.UUID` type is wired. The codegen explicitly checks `f.Type.RType` and skips any other GoType, so a custom UUID field is omitted from the FIQL registry rather than producing a signature-mismatched generated file.
 - **Time values** — must be RFC3339 format (`2006-01-02T15:04:05Z07:00`).
 - **Nesting depth** — maximum 50 levels; deeper expressions return `"maximum nesting depth exceeded"`.
 - **Edge fields** — cross-entity filtering (e.g. `owner.name==john`) is out of scope.

--- a/README.md
+++ b/README.md
@@ -351,14 +351,16 @@ func (User) Fields() []ent.Field {
 
 | Constant | FIQL syntax | Valid for |
 |---|---|---|
-| `EQ` | `==` | all types |
-| `NEQ` | `!=` | all types |
+| `EQ` | `==` | all types (string, int, float, bool, time, enum, uuid) |
+| `NEQ` | `!=` | all types except bool |
 | `GT` | `=gt=` | int, float, time |
 | `LT` | `=lt=` | int, float, time |
 | `GTE` | `=ge=` | int, float, time |
 | `LTE` | `=le=` | int, float, time |
 | `Contains` | `=like=` | string |
 | `HasPrefix` | `=prefix=` | string |
+
+UUID values are parsed via `uuid.Parse` from `github.com/google/uuid` — accepts canonical 36-char hyphenated form, braced (`{...}`), `urn:uuid:...`, and 32-char hex without hyphens.
 
 Logical: `;` = AND, `,` = OR, `(` `)` = grouping. AND binds tighter than OR (standard FIQL precedence).
 
@@ -375,6 +377,7 @@ var UserFIQLFields = entdomain.FIQLFields[predicate.User]{
         NEQ: map[string]predicate.User{"active": user.StatusNEQ(user.StatusActive), "inactive": user.StatusNEQ(user.StatusInactive)},
     },
     "created_at": entdomain.FIQLTime[predicate.User]{GTE: user.CreatedAtGTE, LTE: user.CreatedAtLTE},
+    "external_id": entdomain.FIQLUUID[predicate.User]{EQ: user.ExternalIDEQ, NEQ: user.ExternalIDNEQ},
 }
 
 func UserFIQL(expr string) (predicate.User, error) {
@@ -418,7 +421,7 @@ invalid time value "not-a-time" for field "created_at": ...
 
 ### Known Limitations
 
-- **UUID fields** — not supported; ent's UUID predicates require `uuid.UUID`, not `string`. UUID fields are silently skipped even if annotated.
+- **UUID fields with custom `GoType(...)`** — only the standard `github.com/google/uuid.UUID` type is wired. UUID fields backed by an alternative type via `GoType(...)` fall back to silent-skip.
 - **Time values** — must be RFC3339 format (`2006-01-02T15:04:05Z07:00`).
 - **Nesting depth** — maximum 50 levels; deeper expressions return `"maximum nesting depth exceeded"`.
 - **Edge fields** — cross-entity filtering (e.g. `owner.name==john`) is out of scope.

--- a/adr/scope-support-uuid-in-fiql-query.md
+++ b/adr/scope-support-uuid-in-fiql-query.md
@@ -1,0 +1,60 @@
+# Scope: Support UUID in FIQL queries
+
+| Field    | Value                |
+|----------|----------------------|
+| Status   | Accepted             |
+| Created  | 2026-04-19           |
+| Author   | danhtran94           |
+
+## Problem
+
+UUID fields are silently dropped from generated FIQL registries.
+
+`fieldFIQLKindFn` in `template.go:220-240` returns empty string for the UUID case with the inline comment *"UUID predicates take uuid.UUID not string — not supported via FIQL"*. The template (`template/fiql.tmpl:34`) treats empty-kind fields as "skip", so a schema author who annotates a UUID field with `entdomain.FIQL(...)` gets:
+
+- No build error
+- No warning at codegen
+- The field is absent from the generated `FIQLFields` registry
+- At request time, `ParseFIQL` returns `unknown field "external_id" — annotate with entdomain.FIQL(...) to enable` — the most misleading error possible, because the field *is* annotated
+
+Concrete example: `examples/basic/ent/schema/user.go:48` defines `field.UUID("external_id", uuid.UUID{})`. There is no FIQL annotation today, but the moment one is added, the field stays invisible to `ParseFIQL`. No FIQL test exercises a UUID field — the gap is invisible.
+
+The underlying technical reason is real: ent's UUID predicates take `uuid.UUID`, not `string`, so the existing `apply(op, val string)` interface can't dispatch directly. But UUIDs are first-class identifiers in REST/gRPC APIs (lookup by external ID is the canonical filter), so silently skipping is a usability cliff.
+
+## Success Criteria
+
+1. **New `FIQLUUID[P Predicate]` type** in `fiql.go`, mirroring the structural pattern of `FIQLBool` (single-type wrapper, parses string → typed value, dispatches to ent predicate functions). Supports `==` and `!=` only.
+
+2. **Generator emits `FIQLUUID` descriptors** for ent UUID fields. `fieldFIQLKindFn` in `template.go` returns `"UUID"` for the UUID case (replacing the current `""` skip). Template `template/fiql.tmpl` handles the new kind alongside the existing String/Int/Float/Bool/Time/Enum branches.
+
+3. **Value parsing uses `uuid.Parse`** (the `github.com/google/uuid` package — already a direct dependency per `go.mod`). Invalid UUID strings return `invalid UUID value %q: %w` wrapping the parse error — same shape as the existing int/float/time parse errors.
+
+4. **Disallowed operators return a clear error**: `operator %q not allowed on UUID field — only == and != are supported`. Mirrors the `FIQLBool`/`FIQLEnum` shape.
+
+5. **Round-trip example**: `examples/basic/ent/schema/user.go` `external_id` field gets an `entdomain.FIQL(...)` annotation. Generated `FIQLFields` registry includes it. A new FIQL test in `examples/basic/ent/fiql_test.go` asserts `external_id==<canonical-uuid>` returns the expected user, and `external_id==not-a-uuid` returns the parse error.
+
+6. **`make gen` produces zero diff** after regeneration (CI gate). **`make test` passes** the new UUID test plus all existing FIQL tests unchanged.
+
+## Out of Scope
+
+- **Other ID types beyond `uuid.UUID`.** `xid`, `ulid`, custom string-aliased ID types, or ent's `field.Other(...)` are not addressed. Only `field.UUID` (Google's `github.com/google/uuid` type) is wired. Users on alternative ID libraries will continue to hit the silent-skip behavior; addressing that requires a separate generalization pass.
+
+- **Range / ordering operators (`=gt=`, `=lt=`, `=ge=`, `=le=`).** UUIDs are opaque identifiers; lexicographic ordering is meaningful for v6/v7/v8 only and a footgun for v4. Restricting to `==` / `!=` matches `FIQLBool`/`FIQLEnum` precedent.
+
+- **`=in=` / `=out=` (set membership).** Not present in the existing FIQL grammar for any type. Adding set membership is a separate cross-cutting feature touching the parser (`fiql.go:434-462`) and every typed field — not a UUID-specific concern.
+
+- **UUID as edge / foreign-key filter.** This scope only covers UUID-typed scalar fields. Filtering across edges by the related row's UUID PK is unchanged and remains out of FIQL's scope generally.
+
+- **Non-canonical UUID input forms.** Parsing accepts what `uuid.Parse` accepts (canonical 36-char hyphenated, plus the loose forms that `uuid.Parse` already tolerates — braced, urn:, hex). No additional normalization layer.
+
+- **Generator-time validation that ent's UUID type is actually `github.com/google/uuid.UUID`.** ent supports custom UUID-shaped types via `GoType(...)`. We assume the standard `uuid.UUID`; non-standard underlying types fall back to today's silent-skip behavior. Detection is left to a future scope.
+
+## Risks
+
+- **Breaking existing users with annotated UUID fields.** Today, an `entdomain.FIQL(...)` annotation on a UUID field is a no-op (silent skip). After this change, the same annotation produces a working filter — but any caller currently relying on the field being absent (e.g. allowlist-style validation that assumed UUID would never appear) sees new behavior. *Mitigation:* the silent-skip is itself a defect; nobody should be depending on it. Note in the release commit message and the README's FIQL section.
+
+- **`uuid.Parse` accepting more than canonical 36-char form.** `uuid.Parse` tolerates braced (`{...}`), urn (`urn:uuid:...`), and 32-char hex without hyphens. APIs that want to enforce a single canonical form gain that strictness only by validating upstream. *Mitigation:* document the accepted forms in the `FIQLUUID` Godoc; note that strict-canonical enforcement is an upstream concern.
+
+- **ent UUID fields with custom `GoType(...)`.** A schema using `field.UUID("id", customType{})` where `customType` is not `uuid.UUID` will still fall through to silent-skip (out of scope). The generator does not detect this and won't warn. *Mitigation:* accepted limitation — a follow-up scope can add codegen-time detection and a clear "unsupported UUID GoType" diagnostic. Track as a known gap in the job's Discoveries section if encountered.
+
+- **Living list** — update during implementation as new failure modes surface.

--- a/examples/basic/ent/fiql.go
+++ b/examples/basic/ent/fiql.go
@@ -37,6 +37,10 @@ var UserFIQLFields = entdomain.FIQLFields[predicate.User]{
 		GTE: user.ScoreGTE,
 		LTE: user.ScoreLTE,
 	},
+	"external_id": entdomain.FIQLUUID[predicate.User]{
+		EQ:  user.ExternalIDEQ,
+		NEQ: user.ExternalIDNEQ,
+	},
 }
 
 // UserFIQL parses a FIQL filter expression and returns an ent predicate

--- a/examples/basic/ent/fiql_test.go
+++ b/examples/basic/ent/fiql_test.go
@@ -116,6 +116,24 @@ func TestUserFIQL_GroupingOverridesPrecedence(t *testing.T) {
 	assert.Contains(t, q, "(`users`.`name` = ? OR `users`.`status` = ?) AND `users`.`score` > ?")
 }
 
+func TestUserFIQL_UUIDEQ(t *testing.T) {
+	pred, err := ent.UserFIQL("external_id==550e8400-e29b-41d4-a716-446655440000")
+	require.NoError(t, err)
+	assert.Contains(t, applySQL(pred), "`external_id` = ?")
+}
+
+func TestUserFIQL_UUIDNEQ(t *testing.T) {
+	pred, err := ent.UserFIQL("external_id!=550e8400-e29b-41d4-a716-446655440000")
+	require.NoError(t, err)
+	assert.Contains(t, applySQL(pred), "`external_id` <> ?")
+}
+
+func TestUserFIQL_UUIDInvalid(t *testing.T) {
+	_, err := ent.UserFIQL("external_id==not-a-uuid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid UUID value")
+}
+
 // Error cases on the real generated registry
 
 func TestUserFIQL_UnknownField(t *testing.T) {

--- a/examples/basic/ent/schema/user.go
+++ b/examples/basic/ent/schema/user.go
@@ -45,7 +45,8 @@ func (User) Fields() []ent.Field {
 			Annotations(entdomain.Field(entdomain.SkipProto())),
 		field.Int("score").Optional().
 			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.GT, entdomain.LT, entdomain.GTE, entdomain.LTE))),
-		field.UUID("external_id", uuid.UUID{}),
+		field.UUID("external_id", uuid.UUID{}).
+			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.NEQ))),
 		field.Time("updated_at").Optional(),
 		field.JSON("settings", map[string]any{}).Optional(),
 		// Typed JSON field opted into proto via explicit ProtoType annotation.

--- a/fiql.go
+++ b/fiql.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
+	"github.com/google/uuid"
 )
 
 // FIQLOp is a FIQL comparison operator.
@@ -272,6 +273,38 @@ func (f FIQLBool[P]) apply(op FIQLOp, val string) (P, error) {
 		return zero, fmt.Errorf("operator == not configured on this bool field")
 	}
 	return f.EQ(b), nil
+}
+
+// FIQLUUID handles FIQL filtering for UUID fields (github.com/google/uuid).
+// Values are parsed via uuid.Parse, which accepts canonical 36-char hyphenated
+// form, braced ({...}), urn:uuid:..., and 32-char hex without hyphens.
+// Only == and != are supported — UUIDs are opaque identifiers, so ordering and
+// substring operators are intentionally rejected.
+type FIQLUUID[P Predicate] struct {
+	EQ  func(uuid.UUID) P
+	NEQ func(uuid.UUID) P
+}
+
+func (f FIQLUUID[P]) apply(op FIQLOp, val string) (P, error) {
+	var zero P
+	u, err := uuid.Parse(val)
+	if err != nil {
+		return zero, fmt.Errorf("invalid UUID value %q: %w", val, err)
+	}
+	switch op {
+	case EQ:
+		if f.EQ == nil {
+			return zero, fmt.Errorf("operator == not allowed on this UUID field")
+		}
+		return f.EQ(u), nil
+	case NEQ:
+		if f.NEQ == nil {
+			return zero, fmt.Errorf("operator != not allowed on this UUID field")
+		}
+		return f.NEQ(u), nil
+	default:
+		return zero, fmt.Errorf("operator %q not allowed on UUID field — only == and != are supported", op)
+	}
 }
 
 // FIQLEnum handles FIQL filtering for enum fields.

--- a/fiql_test.go
+++ b/fiql_test.go
@@ -21,6 +21,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/danhtran94/entdomain"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -280,6 +281,53 @@ func TestParseFIQL_BoolField(t *testing.T) {
 	t.Run("non-EQ operator rejected", func(t *testing.T) {
 		_, err := entdomain.ParseFIQL("active=gt=true", fields)
 		require.Error(t, err)
+	})
+}
+
+func TestParseFIQL_UUIDField(t *testing.T) {
+	canonical := "550e8400-e29b-41d4-a716-446655440000"
+	expected := uuid.MustParse(canonical)
+
+	var gotEQ, gotNEQ uuid.UUID
+	fields := entdomain.FIQLFields[testPred]{
+		"external_id": entdomain.FIQLUUID[testPred]{
+			EQ:  func(v uuid.UUID) testPred { return testPred(func(s *sql.Selector) { gotEQ = v }) },
+			NEQ: func(v uuid.UUID) testPred { return testPred(func(s *sql.Selector) { gotNEQ = v }) },
+		},
+	}
+
+	t.Run("EQ canonical", func(t *testing.T) {
+		gotEQ = uuid.Nil
+		pred, err := entdomain.ParseFIQL("external_id=="+canonical, fields)
+		require.NoError(t, err)
+		pred(nil)
+		assert.Equal(t, expected, gotEQ)
+	})
+
+	t.Run("NEQ canonical", func(t *testing.T) {
+		gotNEQ = uuid.Nil
+		pred, err := entdomain.ParseFIQL("external_id!="+canonical, fields)
+		require.NoError(t, err)
+		pred(nil)
+		assert.Equal(t, expected, gotNEQ)
+	})
+
+	t.Run("invalid UUID value", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("external_id==not-a-uuid", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid UUID value")
+	})
+
+	t.Run("ordering operator rejected", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("external_id=gt="+canonical, fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only == and != are supported")
+	})
+
+	t.Run("substring operator rejected", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("external_id=like="+canonical, fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only == and != are supported")
 	})
 }
 

--- a/jobs/ENTD-001-FIQL-support-uuid-in-fiql-query.md
+++ b/jobs/ENTD-001-FIQL-support-uuid-in-fiql-query.md
@@ -1,0 +1,152 @@
+# ENTD-001-FIQL: Support UUID in FIQL queries
+
+| Field      | Value                                                  |
+|------------|--------------------------------------------------------|
+| Status     | Done                                                   |
+| Created    | 2026-04-19                                             |
+| Assignee   | danhtran94                                             |
+| Source     | [scope-support-uuid-in-fiql-query](../docs/scope-support-uuid-in-fiql-query.md) |
+| Blocked by | —                                                      |
+
+## Goal
+Wire `field.UUID` (Google `uuid.UUID`) into the FIQL pipeline end-to-end so that an `entdomain.FIQL(EQ, NEQ)` annotation on a UUID field produces a working filter instead of being silently dropped. Adds a `FIQLUUID[P Predicate]` runtime type that parses values via `uuid.Parse`, flips `fieldFIQLKindFn` to emit `"UUID"` (no template change required — the existing else-branch handles it), annotates `examples/basic` `external_id` to exercise the wiring, and updates the README's Operator Constants table and Known Limitations.
+
+## Problem
+
+    Current (broken):
+      schema annotates UUID field with FIQL(EQ, NEQ)
+        → fieldFIQLKindFn returns ""
+        → template skips field
+        → registry omits field
+        → ParseFIQL returns "unknown field — annotate with FIQL(...) to enable" ✗
+
+## Solution: Add FIQLUUID, mirror FIQLBool shape
+
+    After fix:
+      schema annotates UUID field with FIQL(EQ, NEQ)
+        → fieldFIQLKindFn returns "UUID"
+        → template emits entdomain.FIQLUUID[predicate.X]{EQ: x.FieldEQ, NEQ: x.FieldNEQ}
+        → ParseFIQL parses value via uuid.Parse, dispatches to ent predicate ✓
+
+### Components
+
+**`FIQLUUID[P Predicate]`** — implements `FIQLField[P]`
+- Holds `EQ func(uuid.UUID) P` and `NEQ func(uuid.UUID) P`
+- `apply(op, val)` parses `val` via `uuid.Parse`, errors with `invalid UUID value %q: %w`
+- Rejects any operator other than `==` / `!=` with same wording shape as `FIQLBool`/`FIQLEnum`
+
+**`fieldFIQLKindFn`** — generator type-switch
+- UUID case returns `"UUID"` (was `""`)
+- Template's existing else-branch (`template/fiql.tmpl:54-83`) instantiates `entdomain.FIQLUUID[...]` with EQ/NEQ wiring — no template edit required
+
+### Why not alternatives
+
+| Approach | Verdict |
+|---|---|
+| **`FIQLUUID` mirroring `FIQLBool`** | Chosen. Smallest surface, follows established pattern, template stays untouched. |
+| Generic `FIQLScalar[T any]` parser-injected | Rejected. Requires reworking `FIQLField` interface; bigger change for one type. |
+| Pre-parse UUID in template, emit string-keyed map like enum | Rejected. Forces UUIDs into the enum shape; loses parse-time error context. |
+| Add UUID handling inline to `FIQLString` with a kind tag | Rejected. Conflates two distinct value types; pollutes string codepath. |
+
+## Workstreams
+
+### 1. Runtime FIQL type
+
+Add the `FIQLUUID` value-type wrapper. Unblocks WS2 (generator can reference the new type) and WS4.1 (unit tests).
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1.1 | Add `FIQLUUID[P Predicate]` struct, `apply` method, and `uuid` import | `fiql.go` | [x] |
+
+**Key details:** `apply(op, val string)` parses via `uuid.Parse(val)` (accepts canonical, braced, urn:, and 32-char hex — documented as accepted forms in Godoc). Disallowed-op error: `operator %q not allowed on UUID field — only == and != are supported`. Parse error: `invalid UUID value %q: %w`.
+
+### 2. Generator wiring
+
+Flip the type-switch so UUID kinds are emitted by the template's existing else-branch.
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 2.1 | Change UUID case in `fieldFIQLKindFn` from `""` to `"UUID"` (delete inline skip comment) | `template.go` | [x] |
+
+**Key details:** No template change required. Verified by reading `template/fiql.tmpl:54-83`: the else-branch instantiates `entdomain.FIQL{{ $kind }}[predicate.X]{ EQ: ..., NEQ: ... }` for any kind that's not `Enum`. UUID with EQ/NEQ ops slots in cleanly.
+
+### 3. Example schema annotation
+
+Annotate the existing `external_id` field to exercise the new wiring.
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 3.1 | Add `entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.NEQ))` to `external_id` | `examples/basic/ent/schema/user.go` | [x] |
+
+### 4. Codegen
+
+Regenerate the basic example registry. Job CI gate is `make gen` producing zero diff after a clean rerun.
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 4.1 | Run `make gen-basic`, inspect `examples/basic/ent/fiql.go` for new `external_id` entry, confirm UserFIQLFields contains `FIQLUUID` registration | `examples/basic/ent/fiql.go` (output) | [x] |
+| 4.2 | Run `make gen` to regenerate both examples; confirm second run shows zero diff | all generated outputs | [x] |
+
+### 5. Testing
+
+| # | Task | Status |
+|---|------|--------|
+| 5.1 | Unit test `FIQLUUID.apply` — valid UUID + EQ/NEQ, invalid UUID returns parse error, disallowed op returns correct error | [x] |
+| 5.2 | Integration test in basic example: `external_id==<canonical-uuid>` produces `external_id = ?` SQL; `external_id==not-a-uuid` returns parse error | [x] |
+
+**Key details:** Unit test goes in root `fiql_test.go` next to existing `FIQLBool`-style tests. Integration test goes in `examples/basic/ent/fiql_test.go` and uses the same `applySQL` helper as `TestUserFIQL_SimpleEQ`.
+
+### 6. Documentation
+
+| # | Task | Status |
+|---|------|--------|
+| 6.1 | README Operator Constants table (~L352) — extend "Valid for" rows for `EQ`/`NEQ` to include `uuid` | [x] |
+| 6.2 | README Generated Code example (~L370) — add `external_id` line showing `entdomain.FIQLUUID[predicate.User]{...}` | [x] |
+| 6.3 | README Known Limitations (~L421) — replace "UUID fields silently skipped" with the GoType-only caveat | [x] |
+
+## Design Decisions
+
+### `==` and `!=` only — no ordering / set membership
+UUIDs are opaque identifiers. Lexicographic compare is meaningful only for v6/v7/v8 and a footgun for v4. Set membership (`=in=`) doesn't exist for any FIQL type yet — separate cross-cutting feature. Out of scope per the source scope note.
+
+### Template stays untouched
+The existing else-branch already handles arbitrary `FIQL{{ $kind }}` instantiations with `EQ`/`NEQ`/etc. wiring. Changing the template would add risk without benefit; the cleanest fix is just to flip the kind string.
+
+### Accept `uuid.Parse`'s loose forms
+`uuid.Parse` tolerates braced (`{...}`), urn (`urn:uuid:...`), and 32-char hex without hyphens in addition to canonical 36-char. Documented as accepted — strict-canonical enforcement is upstream's problem.
+
+## What Stays Unchanged
+- `template/fiql.tmpl` — no edit; the else-branch (lines 54-83) already handles the new kind
+- FIQL parser (`fiqlParser` in `fiql.go:346-517`) — UUIDs use the existing comparison/atom path
+- `examples/custom` — no UUID fields in that schema; nothing to wire there
+- ent UUID predicates — generated by ent unchanged
+- Proto generation — unrelated; the proto type mapping (README L802/L804) is untouched
+
+## Implementation Order
+
+    1. WS1: FIQLUUID runtime          ← unblocks WS2, WS5.1
+    2. WS2: fieldFIQLKindFn change    ← depends on WS1 type existing
+    3. WS3: example schema annotation ← independent of WS1/2 but only useful after both
+    4. WS4: regenerate                ← requires WS1+WS2+WS3
+    5. WS5: tests                     ← 5.1 needs WS1; 5.2 needs WS4
+    6. WS6: README updates            ← last; after behavior is verified
+
+## Notes
+- `github.com/google/uuid` is already a direct dependency (`go.mod`); no new module required
+- `make gen` is the CI gate — must produce zero diff after a clean rerun
+- Verification cadence per task: `go build ./...` + `make test` after every code edit; `make gen` after WS3
+- The current "silently skipped" defect has no test coverage, so this job both fixes the gap and adds the missing test
+
+## Discoveries & Decisions During Implementation
+(Filled during execution — never during planning)
+
+### [Implementer] `apply` parses value before checking operator
+First draft of the unit test asserted that `external_id=like=550e` would return the "operator not allowed" error. It returned `invalid UUID value` instead. Root cause: `FIQLUUID.apply` parses with `uuid.Parse(val)` before the op-validation switch — same shape as `FIQLBool.apply` (`fiql.go:262`), which parses the bool first then rejects non-EQ ops. This is consistent precedent, not a defect: the op-rejection error is reachable only when the value happens to parse. Fix: rewrote the disallowed-op tests to use a valid canonical UUID with the disallowed operator, isolating the op-validation path. Worth knowing for any future "unsupported operator on parsed type" test — exercise it with a value that parses cleanly.
+
+### [Implementer] Postbuild hook fires per-Edit, not per-batch
+Adding the `uuid` import to `fiql.go` in one edit triggered `harness hook-postbuild`, which ran `make gen-basic`, which compiled `fiql.go` with an unused import — hard fail. The `FIQLUUID` type that consumed the import was a separate edit. Lesson: edits that cross a compile boundary (introducing an import + the symbol that uses it) must be batched into a single Edit call, OR the new symbol must be added before the import. Handled here by following up immediately with the type-adding edit; if it had been a longer pause, the working tree would be broken. Same hazard applies to any future split between "infrastructure" and "use site" edits.
+
+### [Implementer] No template change required — confirmed by zero-diff regen
+The plan predicted that `template/fiql.tmpl:54-83`'s else-branch (the catchall for non-Enum kinds) would handle UUID without edits. Confirmed in practice: after flipping `fieldFIQLKindFn` to return `"UUID"`, `make gen` produced exactly the expected `entdomain.FIQLUUID[predicate.User]{EQ: user.ExternalIDEQ, NEQ: user.ExternalIDNEQ}` registry entry, and a second `make gen` showed zero diff. The template's else-branch is a true generic over `(kind, ops)` — any future scalar type with EQ/NEQ/etc. wiring can be added the same way (runtime type + kind string flip, no template touch).
+
+<!-- approved -->

--- a/template.go
+++ b/template.go
@@ -216,7 +216,12 @@ func fieldFIQLAnnotationFn(f *gen.Field) ([]string, error) {
 }
 
 // fieldFIQLKindFn returns the FIQL type kind string for a field:
-// "String", "Int", "Float", "Bool", "Time", "Enum", or "" (unsupported).
+// "String", "Int", "Float", "Bool", "Time", "Enum", "UUID", or "" (unsupported).
+//
+// UUID fields are emitted only when the underlying Go type is the canonical
+// github.com/google/uuid.UUID. ent generates predicate methods using the
+// field's actual GoType, so a custom GoType would produce a signature
+// mismatch when wired into FIQLUUID (which takes uuid.UUID).
 func fieldFIQLKindFn(f *gen.Field) string {
 	switch f.Type.Type {
 	case field.TypeString:
@@ -233,7 +238,12 @@ func fieldFIQLKindFn(f *gen.Field) string {
 	case field.TypeEnum:
 		return "Enum"
 	case field.TypeUUID:
-		return "UUID"
+		if f.Type.RType != nil &&
+			f.Type.RType.PkgPath == "github.com/google/uuid" &&
+			f.Type.RType.Ident == "uuid.UUID" {
+			return "UUID"
+		}
+		return "" // custom GoType: predicates take the custom type, not uuid.UUID
 	default:
 		return "" // JSON and others: not supported
 	}

--- a/template.go
+++ b/template.go
@@ -233,7 +233,7 @@ func fieldFIQLKindFn(f *gen.Field) string {
 	case field.TypeEnum:
 		return "Enum"
 	case field.TypeUUID:
-		return "" // UUID predicates take uuid.UUID not string — not supported via FIQL
+		return "UUID"
 	default:
 		return "" // JSON and others: not supported
 	}

--- a/template_internal_test.go
+++ b/template_internal_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entdomain
+
+import (
+	"testing"
+
+	"entgo.io/ent/entc/gen"
+	"entgo.io/ent/schema/field"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldFIQLKind_UUID(t *testing.T) {
+	t.Run("standard uuid.UUID emits UUID kind", func(t *testing.T) {
+		f := &gen.Field{}
+		f.Type = &field.TypeInfo{
+			Type: field.TypeUUID,
+			RType: &field.RType{
+				PkgPath: "github.com/google/uuid",
+				Ident:   "uuid.UUID",
+			},
+		}
+		assert.Equal(t, "UUID", fieldFIQLKindFn(f))
+	})
+
+	t.Run("custom GoType is skipped to avoid signature mismatch", func(t *testing.T) {
+		f := &gen.Field{}
+		f.Type = &field.TypeInfo{
+			Type: field.TypeUUID,
+			RType: &field.RType{
+				PkgPath: "example.com/custom",
+				Ident:   "custom.MyUUID",
+			},
+		}
+		assert.Equal(t, "", fieldFIQLKindFn(f))
+	})
+
+	t.Run("nil RType is skipped", func(t *testing.T) {
+		f := &gen.Field{}
+		f.Type = &field.TypeInfo{Type: field.TypeUUID}
+		assert.Equal(t, "", fieldFIQLKindFn(f))
+	})
+}


### PR DESCRIPTION
## What
Adds `FIQLUUID[P Predicate]` runtime type that parses values via `uuid.Parse` and dispatches to ent's UUID predicates. Generator now emits `"UUID"` instead of `""` for `field.UUID` kinds, so annotated UUID fields appear in the `FIQLFields` registry instead of being silently dropped at codegen. Supports `==` and `!=` only — UUIDs are opaque, ordering/substring operators are intentionally rejected.

## Why
- Source scope: [`docs/scope-support-uuid-in-fiql-query.md`](docs/scope-support-uuid-in-fiql-query.md)
- Job doc:     [`jobs/ENTD-001-FIQL-support-uuid-in-fiql-query.md`](jobs/ENTD-001-FIQL-support-uuid-in-fiql-query.md)

Before this fix, an `entdomain.FIQL(EQ, NEQ)` annotation on a `field.UUID` was a silent no-op — the field was dropped from the registry, then `ParseFIQL` returned the misleading `unknown field "external_id" — annotate with entdomain.FIQL(...) to enable`. UUIDs are first-class identifiers in REST/gRPC APIs, so silent-skip was a usability cliff.

## How to test
```sh
make build
make test
make gen && git diff --exit-code   # zero diff after regen
```

Concrete UUID exercise (basic example, real generated registry):
```sh
go test -run "TestUserFIQL_UUID" -v ./examples/basic/ent/...
```

Unit tests on the runtime type:
```sh
go test -run TestParseFIQL_UUIDField -v .
```

## Notes
- **Template untouched** — the existing else-branch in `template/fiql.tmpl:54-83` already handles arbitrary `FIQL{{kind}}` instantiations with `EQ`/`NEQ` wiring; only `fieldFIQLKindFn` needed flipping.
- **Out of scope** (per source scope note): `xid`/`ulid`/custom GoTypes, ordering ops, set membership (`=in=`), edge filters. README's Known Limitations now calls out the GoType caveat explicitly.
- Behavioral change: an annotation that was silently a no-op now produces a working filter. The pre-existing silent-skip was itself a defect; nothing should depend on it.

## Checklist
- [x] Tests added (5 unit subtests in `fiql_test.go`, 3 integration tests in `examples/basic/ent/fiql_test.go`)
- [x] `make gen` run; second run shows zero diff
- [x] No new ADR/RFC required (scope note already captures the decision)
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UUID fields now support equality (==) and inequality (!=) filtering in FIQL queries.
  * FIQL parsing accepts canonical hyphenated, braced, urn:uuid:, and 32-char hex UUID formats.

* **Documentation**
  * Operator docs updated to show UUID support for EQ/NEQ and clarified which UUID field configurations are recognized (only standard UUID-typed fields).

* **Tests & Examples**
  * Added unit and integration tests and example coverage for UUID FIQL parsing, valid/invalid inputs, and operator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->