### PR TITLE
feat(fiql): set membership operators =in= and =out= (ENTD-002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ func (User) Fields() []ent.Field {
 | `LTE` | `=le=` | int, float, time |
 | `Contains` | `=like=` | string |
 | `HasPrefix` | `=prefix=` | string |
+| `In` | `=in=` | string, int, float, enum, uuid (value syntax: `field=in=(a,b,c)`) |
+| `NotIn` | `=out=` | string, int, float, enum, uuid (value syntax: `field=out=(a,b,c)`) |
 
 UUID values are parsed via `uuid.Parse` from `github.com/google/uuid` — accepts canonical 36-char hyphenated form, braced (`{...}`), `urn:uuid:...`, and 32-char hex without hyphens.
 
@@ -371,7 +373,7 @@ Logical: `;` = AND, `,` = OR, `(` `)` = grouping. AND binds tighter than OR (sta
 
 var UserFIQLFields = entdomain.FIQLFields[predicate.User]{
     "name":       entdomain.FIQLString[predicate.User]{EQ: user.NameEQ, NEQ: user.NameNEQ, Contains: user.NameContains},
-    "score":      entdomain.FIQLInt[predicate.User]{EQ: user.ScoreEQ, GT: user.ScoreGT, LT: user.ScoreLT, GTE: user.ScoreGTE, LTE: user.ScoreLTE},
+    "score":      entdomain.FIQLInt[predicate.User]{EQ: user.ScoreEQ, GT: user.ScoreGT, LT: user.ScoreLT, GTE: user.ScoreGTE, LTE: user.ScoreLTE, In: user.ScoreIn, NotIn: user.ScoreNotIn},
     "status":     entdomain.FIQLEnum[predicate.User]{
         EQ:  map[string]predicate.User{"active": user.StatusEQ(user.StatusActive), "inactive": user.StatusEQ(user.StatusInactive)},
         NEQ: map[string]predicate.User{"active": user.StatusNEQ(user.StatusActive), "inactive": user.StatusNEQ(user.StatusInactive)},
@@ -422,6 +424,7 @@ invalid time value "not-a-time" for field "created_at": ...
 ### Known Limitations
 
 - **UUID fields with custom `GoType(...)`** — only the canonical `github.com/google/uuid.UUID` type is wired. The codegen explicitly checks `f.Type.RType` and skips any other GoType, so a custom UUID field is omitted from the FIQL registry rather than producing a signature-mismatched generated file.
+- **`=in=` / `=out=` constraints** — bool and time fields don't support set membership (`=in=(true,false)` is meaningless; time uses range operators). Maximum 100 values per list. Values containing `,` or `)` cannot be used in lists — chain `==` / `!=` for those.
 - **Time values** — must be RFC3339 format (`2006-01-02T15:04:05Z07:00`).
 - **Nesting depth** — maximum 50 levels; deeper expressions return `"maximum nesting depth exceeded"`.
 - **Edge fields** — cross-entity filtering (e.g. `owner.name==john`) is out of scope.

--- a/docs/scope-fiql-set-membership.md
+++ b/docs/scope-fiql-set-membership.md
@@ -1,0 +1,79 @@
+# Scope: FIQL set membership (`=in=` / `=out=`)
+
+| Field    | Value                |
+|----------|----------------------|
+| Status   | Accepted             |
+| Created  | 2026-04-19           |
+| Author   | danhtran94           |
+
+## Problem
+
+FIQL today has no set-membership operator. Users wanting "field is one of N values" must chain equality terms:
+
+    status==open,status==pending,status==closed
+
+This is verbose, scales linearly with the value count, and produces an OR-of-EQ SQL plan instead of the SQL `IN (...)` plan ent's `FieldIn` predicates already generate. The exclusion variant (`field is none of N values`) is even uglier:
+
+    status!=open;status!=pending;status!=closed
+
+Both patterns also miss the standard FIQL `=in=` / `=out=` operators that REST clients commonly expect (every other typed FIQL field already follows the FIQL spec — set-membership is the conspicuous gap).
+
+The blocker isn't ent — `user.NameIn(vs ...string)` and `user.NameNotIn(...)` already exist for every typed field. The blocker is the parser: `readValue` (`fiql.go:507-517`) stops on the first `,` or `)`, so `field=in=(a,b,c)` is unparseable today. The runtime field types (`FIQLString`, `FIQLInt`, `FIQLFloat`, `FIQLEnum`, `FIQLUUID`) also have no slot to receive a list.
+
+## Success Criteria
+
+1. **Two new operator constants** in `fiql.go`: `In FIQLOp = "=in="` and `NotIn FIQLOp = "=out="`. Both accepted by the FIQL annotation system (`entdomain.FIQL(entdomain.In, entdomain.NotIn)`).
+
+2. **Parser handles `(a,b,c)` value form.** When the comparison operator is `In` or `NotIn`, the parser reads a parenthesised value via a new `readListValue` helper that consumes from `(` to the matching `)`. Inner commas are part of the value list, not OR separators. Nested parens are not supported (lists are flat). Standard `==`, `!=`, `=gt=` etc. continue using the existing `readValue` unchanged.
+
+3. **Field-type slots added** to runtime types in `fiql.go`:
+   - `FIQLString[P]` gains `In func(...string) P` and `NotIn func(...string) P`
+   - `FIQLInt[P]`, `FIQLFloat[P]`, `FIQLUUID[P]` gain analogous `In`/`NotIn` with their respective scalar types
+   - `FIQLEnum[P]` does NOT gain new fields. Set-membership for enums is built by OR-ing entries from the existing `EQ` map (and AND-ing entries from `NEQ` for `=out=`). Same SQL semantics as the typed `FieldIn`, no new wiring required.
+
+4. **`apply` methods parse the list value** by stripping outer parens and splitting on `,`. Empty lists (`()`) return a clear parse error: `empty value list for =in= operator`. Each element is parsed with the existing per-type parser (e.g. `strconv.Atoi` for int, `uuid.Parse` for UUID); a single bad element fails the whole expression with the offending value named.
+
+5. **List size cap** of 100 elements per `=in=`/`=out=` term — matching the `maxFIQLDepth = 50` precedent. Exceeding the cap returns `=in= list exceeds maximum of 100 values`. Defined as a top-level `maxFIQLListValues` constant for symmetry with `maxFIQLDepth`.
+
+6. **Generator emits the new wirings** in `template/fiql.tmpl`. The else-branch (the `FIQL{{kind}}` instantiation that already handles String/Int/Float/Bool/Time/UUID) gains two new `if eq $op` branches:
+   ```
+   {{- if eq $op "=in=" }}
+   In: {{ lower $n.Name }}.{{ $f.StructField }}In,
+   {{- end }}
+   {{- if eq $op "=out=" }}
+   NotIn: {{ lower $n.Name }}.{{ $f.StructField }}NotIn,
+   {{- end }}
+   ```
+   The Enum branch is unchanged — set-membership for enums uses the existing EQ/NEQ maps at apply time.
+
+7. **Round-trip example** in `examples/basic`: `status` (enum) and `score` (int) get `entdomain.In` / `entdomain.NotIn` added to their FIQL annotations. New tests in `fiql_test.go` (root) cover the runtime types; new integration tests in `examples/basic/ent/fiql_test.go` assert `score=in=(10,20,30)` produces SQL containing `IN (?` and `status=out=(open,closed)` produces an AND-of-NEQ.
+
+8. **`make gen` zero-diff after regen.** `make test` passes the new `=in=` / `=out=` tests plus all existing FIQL tests unchanged.
+
+## Out of Scope
+
+- **Bool fields.** `=in=(true,false)` is always-true and `=in=(true)` is identical to `==true`. Adding the slot to `FIQLBool` is dead code. `entdomain.FIQL(entdomain.In, ...)` on a bool field returns the existing "operator not allowed" error.
+
+- **Time fields.** Range queries (`=gt=` / `=le=`) are the right idiom for time. Set-membership over discrete timestamps is a corner case and the value parsing (RFC3339 with embedded `:` and `T`) interacts awkwardly with the comma list separator. Deferred until a concrete user need surfaces.
+
+- **Escape syntax for values containing `,` or `)`.** FIQL standards don't define one. Values with commas or close-parens cannot be used in `=in=`/`=out=` lists; use chained `==` / `!=` for those. Documented in the README.
+
+- **Nested lists or set algebra.** `=in=(a,(b,c))`, `=in=(set1) AND =out=(set2)` collapsed expressions, etc. Not addressed — the existing `;` (AND) and `,` (OR) grammar at the term level still composes membership expressions.
+
+- **Custom GoType UUID set membership.** Inherits the same gate from ENTD-001 — custom-GoType UUID fields are skipped at codegen, including for `=in=`. No new gate logic required.
+
+- **Server-side cap configurability.** The 100-element cap is a hard constant. Making it tunable via annotation or environment is deferred — pick a sensible default first, expose configurability if a user actually needs it.
+
+- **`=in=` value type that differs from the field's scalar type.** Each list element is parsed with the same per-type parser as `==`. No coercion (e.g. `score=in=("10","20")` with stringified ints) — this would diverge from the rest of FIQL's contract.
+
+## Risks
+
+- **Parser regression on existing expressions containing `(...)` for grouping.** The current parser reads `(` only inside `parseAtom` for sub-expressions. The new `readListValue` is reachable only after a `=in=` / `=out=` operator is matched, so the grouping path is untouched. *Mitigation:* keep all existing parser tests green (they already cover precedence and grouping); add a regression test specifically asserting `(name==a,name==b)` still parses as grouped-OR even with the new operator constants present.
+
+- **List-cap defense vs. usability.** A 100-element cap protects parse time and downstream SQL planner cost. But genuine bulk-filter use cases (e.g. "users in this 200-row CSV") will hit it. *Mitigation:* document the cap in the README with the chained-equality fallback for larger sets; revisit if a real user needs >100 (configurable cap is a clean follow-up scope).
+
+- **Empty-list error vs. always-false convention.** Choosing parse-error means `=in=()` from an upstream caller (perhaps an unfiltered CSV import path) hard-fails the request rather than returning zero rows. The opposite choice (silent always-false) hides bugs in caller code. *Mitigation:* parse-error is the louder, less-buggy default; callers handling user input should validate non-empty before constructing the FIQL expression.
+
+- **Different SQL plans for enum `=in=` (OR-of-EQ) vs. typed `=in=` (`IN (...)`)** could surprise reviewers expecting symmetry. *Mitigation:* document the difference in the README's FIQL section; performance is equivalent on every supported DB engine (the planner collapses OR-of-EQ-on-same-column to an IN scan), so this is purely cosmetic in the generated SQL.
+
+- **Living list** — update during implementation as new failure modes surface.

--- a/docs/scope-fiql-set-membership.md
+++ b/docs/scope-fiql-set-membership.md
@@ -36,17 +36,17 @@ The blocker isn't ent — `user.NameIn(vs ...string)` and `user.NameNotIn(...)` 
 5. **List size cap** of 100 elements per `=in=`/`=out=` term — matching the `maxFIQLDepth = 50` precedent. Exceeding the cap returns `=in= list exceeds maximum of 100 values`. Defined as a top-level `maxFIQLListValues` constant for symmetry with `maxFIQLDepth`.
 
 6. **Generator emits the new wirings** in `template/fiql.tmpl`. The else-branch (the `FIQL{{kind}}` instantiation that already handles String/Int/Float/Bool/Time/UUID) gains two new `if eq $op` branches:
-   ```
-   {{- if eq $op "=in=" }}
-   In: {{ lower $n.Name }}.{{ $f.StructField }}In,
-   {{- end }}
-   {{- if eq $op "=out=" }}
-   NotIn: {{ lower $n.Name }}.{{ $f.StructField }}NotIn,
-   {{- end }}
-   ```
+
+       {{- if eq $op "=in=" }}
+       In: {{ lower $n.Name }}.{{ $f.StructField }}In,
+       {{- end }}
+       {{- if eq $op "=out=" }}
+       NotIn: {{ lower $n.Name }}.{{ $f.StructField }}NotIn,
+       {{- end }}
+
    The Enum branch is unchanged — set-membership for enums uses the existing EQ/NEQ maps at apply time.
 
-7. **Round-trip example** in `examples/basic`: `status` (enum) and `score` (int) get `entdomain.In` / `entdomain.NotIn` added to their FIQL annotations. New tests in `fiql_test.go` (root) cover the runtime types; new integration tests in `examples/basic/ent/fiql_test.go` assert `score=in=(10,20,30)` produces SQL containing `IN (?` and `status=out=(open,closed)` produces an AND-of-NEQ.
+7. **Round-trip example** in `examples/basic`: `status` (enum) and `score` (int) get `entdomain.In` / `entdomain.NotIn` added to their FIQL annotations. New tests in `fiql_test.go` (root) cover the runtime types; new integration tests in `examples/basic/ent/fiql_test.go` assert `score=in=(10,20,30)` produces SQL containing `IN (?` and `status=out=(active,inactive)` produces an AND-of-NEQ.
 
 8. **`make gen` zero-diff after regen.** `make test` passes the new `=in=` / `=out=` tests plus all existing FIQL tests unchanged.
 

--- a/examples/basic/ent/fiql.go
+++ b/examples/basic/ent/fiql.go
@@ -31,11 +31,13 @@ var UserFIQLFields = entdomain.FIQLFields[predicate.User]{
 		LTE: user.CreatedAtLTE,
 	},
 	"score": entdomain.FIQLInt[predicate.User]{
-		EQ:  user.ScoreEQ,
-		GT:  user.ScoreGT,
-		LT:  user.ScoreLT,
-		GTE: user.ScoreGTE,
-		LTE: user.ScoreLTE,
+		EQ:    user.ScoreEQ,
+		GT:    user.ScoreGT,
+		LT:    user.ScoreLT,
+		GTE:   user.ScoreGTE,
+		LTE:   user.ScoreLTE,
+		In:    user.ScoreIn,
+		NotIn: user.ScoreNotIn,
 	},
 	"external_id": entdomain.FIQLUUID[predicate.User]{
 		EQ:  user.ExternalIDEQ,

--- a/examples/basic/ent/fiql_test.go
+++ b/examples/basic/ent/fiql_test.go
@@ -134,6 +134,48 @@ func TestUserFIQL_UUIDInvalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid UUID value")
 }
 
+func TestUserFIQL_IntIn(t *testing.T) {
+	pred, err := ent.UserFIQL("score=in=(10,20,30)")
+	require.NoError(t, err)
+	q := applySQL(pred)
+	assert.Contains(t, q, "`score` IN (?")
+}
+
+func TestUserFIQL_IntNotIn(t *testing.T) {
+	pred, err := ent.UserFIQL("score=out=(10,20)")
+	require.NoError(t, err)
+	q := applySQL(pred)
+	assert.Contains(t, q, "`score` NOT IN (?")
+}
+
+func TestUserFIQL_EnumIn(t *testing.T) {
+	// Enum =in= composes via OR-of-EQ at apply time (no FieldIn predicate generated).
+	pred, err := ent.UserFIQL("status=in=(active,inactive)")
+	require.NoError(t, err)
+	q := applySQL(pred)
+	assert.Contains(t, q, "OR")
+	assert.Contains(t, q, "`status` = ?")
+}
+
+func TestUserFIQL_EnumNotIn(t *testing.T) {
+	pred, err := ent.UserFIQL("status=out=(active)")
+	require.NoError(t, err)
+	q := applySQL(pred)
+	assert.Contains(t, q, "`status` <> ?")
+}
+
+func TestUserFIQL_InEmptyList(t *testing.T) {
+	_, err := ent.UserFIQL("score=in=()")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty value list")
+}
+
+func TestUserFIQL_InBadElement(t *testing.T) {
+	_, err := ent.UserFIQL("score=in=(10,abc)")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid integer value "abc" in list`)
+}
+
 // Error cases on the real generated registry
 
 func TestUserFIQL_UnknownField(t *testing.T) {

--- a/examples/basic/ent/schema/user.go
+++ b/examples/basic/ent/schema/user.go
@@ -38,13 +38,13 @@ func (User) Fields() []ent.Field {
 			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.NEQ, entdomain.Contains))),
 		field.String("bio").Optional(),
 		field.Enum("status").Values("active", "inactive").Default("active").
-			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.NEQ))),
+			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.NEQ, entdomain.In, entdomain.NotIn))),
 		field.Time("created_at").Default(time.Now).Immutable().
 			Annotations(entdomain.Field(entdomain.FIQL(entdomain.GTE, entdomain.LTE))),
 		field.String("username").Immutable().
 			Annotations(entdomain.Field(entdomain.SkipProto())),
 		field.Int("score").Optional().
-			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.GT, entdomain.LT, entdomain.GTE, entdomain.LTE))),
+			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.GT, entdomain.LT, entdomain.GTE, entdomain.LTE, entdomain.In, entdomain.NotIn))),
 		field.UUID("external_id", uuid.UUID{}).
 			Annotations(entdomain.Field(entdomain.FIQL(entdomain.EQ, entdomain.NEQ))),
 		field.Time("updated_at").Optional(),

--- a/fiql.go
+++ b/fiql.go
@@ -138,6 +138,12 @@ type FIQLInt[P Predicate] struct {
 func (f FIQLInt[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
 	if op == In || op == NotIn {
+		if op == In && f.In == nil {
+			return zero, fmt.Errorf("operator =in= not allowed on this int field")
+		}
+		if op == NotIn && f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this int field")
+		}
 		parts, err := parseInListValue(val)
 		if err != nil {
 			return zero, err
@@ -151,13 +157,7 @@ func (f FIQLInt[P]) apply(op FIQLOp, val string) (P, error) {
 			ns[i] = n
 		}
 		if op == In {
-			if f.In == nil {
-				return zero, fmt.Errorf("operator =in= not allowed on this int field")
-			}
 			return f.In(ns...), nil
-		}
-		if f.NotIn == nil {
-			return zero, fmt.Errorf("operator =out= not allowed on this int field")
 		}
 		return f.NotIn(ns...), nil
 	}
@@ -216,6 +216,12 @@ type FIQLFloat[P Predicate] struct {
 func (f FIQLFloat[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
 	if op == In || op == NotIn {
+		if op == In && f.In == nil {
+			return zero, fmt.Errorf("operator =in= not allowed on this float field")
+		}
+		if op == NotIn && f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this float field")
+		}
 		parts, err := parseInListValue(val)
 		if err != nil {
 			return zero, err
@@ -229,13 +235,7 @@ func (f FIQLFloat[P]) apply(op FIQLOp, val string) (P, error) {
 			ns[i] = n
 		}
 		if op == In {
-			if f.In == nil {
-				return zero, fmt.Errorf("operator =in= not allowed on this float field")
-			}
 			return f.In(ns...), nil
-		}
-		if f.NotIn == nil {
-			return zero, fmt.Errorf("operator =out= not allowed on this float field")
 		}
 		return f.NotIn(ns...), nil
 	}
@@ -368,6 +368,12 @@ type FIQLUUID[P Predicate] struct {
 func (f FIQLUUID[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
 	if op == In || op == NotIn {
+		if op == In && f.In == nil {
+			return zero, fmt.Errorf("operator =in= not allowed on this UUID field")
+		}
+		if op == NotIn && f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this UUID field")
+		}
 		parts, err := parseInListValue(val)
 		if err != nil {
 			return zero, err
@@ -381,13 +387,7 @@ func (f FIQLUUID[P]) apply(op FIQLOp, val string) (P, error) {
 			us[i] = u
 		}
 		if op == In {
-			if f.In == nil {
-				return zero, fmt.Errorf("operator =in= not allowed on this UUID field")
-			}
 			return f.In(us...), nil
-		}
-		if f.NotIn == nil {
-			return zero, fmt.Errorf("operator =out= not allowed on this UUID field")
 		}
 		return f.NotIn(us...), nil
 	}

--- a/fiql.go
+++ b/fiql.go
@@ -45,6 +45,12 @@ const (
 	Contains FIQLOp = "=like="
 	// HasPrefix matches field LIKE 'value%' (string).
 	HasPrefix FIQLOp = "=prefix="
+	// In matches field IN (v1, v2, ...) — value syntax: =in=(a,b,c).
+	// Supported on string, int, float, enum, uuid fields.
+	In FIQLOp = "=in="
+	// NotIn matches field NOT IN (v1, v2, ...) — value syntax: =out=(a,b,c).
+	// Supported on string, int, float, enum, uuid fields.
+	NotIn FIQLOp = "=out="
 )
 
 // Predicate is a constraint for ent predicate types. All ent predicate types have
@@ -67,6 +73,8 @@ type FIQLString[P Predicate] struct {
 	NEQ       func(string) P
 	Contains  func(string) P
 	HasPrefix func(string) P
+	In        func(...string) P
+	NotIn     func(...string) P
 }
 
 func (f FIQLString[P]) apply(op FIQLOp, val string) (P, error) {
@@ -92,6 +100,24 @@ func (f FIQLString[P]) apply(op FIQLOp, val string) (P, error) {
 			return zero, fmt.Errorf("operator =prefix= not allowed on this string field")
 		}
 		return f.HasPrefix(val), nil
+	case In:
+		if f.In == nil {
+			return zero, fmt.Errorf("operator =in= not allowed on this string field")
+		}
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		return f.In(parts...), nil
+	case NotIn:
+		if f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this string field")
+		}
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		return f.NotIn(parts...), nil
 	default:
 		return zero, fmt.Errorf("operator %q not allowed on string field", op)
 	}
@@ -99,16 +125,42 @@ func (f FIQLString[P]) apply(op FIQLOp, val string) (P, error) {
 
 // FIQLInt handles FIQL filtering for integer fields.
 type FIQLInt[P Predicate] struct {
-	EQ  func(int) P
-	NEQ func(int) P
-	GT  func(int) P
-	LT  func(int) P
-	GTE func(int) P
-	LTE func(int) P
+	EQ    func(int) P
+	NEQ   func(int) P
+	GT    func(int) P
+	LT    func(int) P
+	GTE   func(int) P
+	LTE   func(int) P
+	In    func(...int) P
+	NotIn func(...int) P
 }
 
 func (f FIQLInt[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
+	if op == In || op == NotIn {
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		ns := make([]int, len(parts))
+		for i, s := range parts {
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				return zero, fmt.Errorf("invalid integer value %q in list: %w", s, err)
+			}
+			ns[i] = n
+		}
+		if op == In {
+			if f.In == nil {
+				return zero, fmt.Errorf("operator =in= not allowed on this int field")
+			}
+			return f.In(ns...), nil
+		}
+		if f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this int field")
+		}
+		return f.NotIn(ns...), nil
+	}
 	n, err := strconv.Atoi(val)
 	if err != nil {
 		return zero, fmt.Errorf("invalid integer value %q: %w", val, err)
@@ -151,16 +203,42 @@ func (f FIQLInt[P]) apply(op FIQLOp, val string) (P, error) {
 
 // FIQLFloat handles FIQL filtering for float fields.
 type FIQLFloat[P Predicate] struct {
-	EQ  func(float64) P
-	NEQ func(float64) P
-	GT  func(float64) P
-	LT  func(float64) P
-	GTE func(float64) P
-	LTE func(float64) P
+	EQ    func(float64) P
+	NEQ   func(float64) P
+	GT    func(float64) P
+	LT    func(float64) P
+	GTE   func(float64) P
+	LTE   func(float64) P
+	In    func(...float64) P
+	NotIn func(...float64) P
 }
 
 func (f FIQLFloat[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
+	if op == In || op == NotIn {
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		ns := make([]float64, len(parts))
+		for i, s := range parts {
+			n, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return zero, fmt.Errorf("invalid float value %q in list: %w", s, err)
+			}
+			ns[i] = n
+		}
+		if op == In {
+			if f.In == nil {
+				return zero, fmt.Errorf("operator =in= not allowed on this float field")
+			}
+			return f.In(ns...), nil
+		}
+		if f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this float field")
+		}
+		return f.NotIn(ns...), nil
+	}
 	n, err := strconv.ParseFloat(val, 64)
 	if err != nil {
 		return zero, fmt.Errorf("invalid float value %q: %w", val, err)
@@ -262,12 +340,12 @@ type FIQLBool[P Predicate] struct {
 
 func (f FIQLBool[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
+	if op != EQ {
+		return zero, fmt.Errorf("operator %q not allowed on bool field — only == is supported", op)
+	}
 	b, err := strconv.ParseBool(val)
 	if err != nil {
 		return zero, fmt.Errorf("invalid bool value %q (expected true or false): %w", val, err)
-	}
-	if op != EQ {
-		return zero, fmt.Errorf("operator %q not allowed on bool field — only == is supported", op)
 	}
 	if f.EQ == nil {
 		return zero, fmt.Errorf("operator == not configured on this bool field")
@@ -281,12 +359,38 @@ func (f FIQLBool[P]) apply(op FIQLOp, val string) (P, error) {
 // Only == and != are supported — UUIDs are opaque identifiers, so ordering and
 // substring operators are intentionally rejected.
 type FIQLUUID[P Predicate] struct {
-	EQ  func(uuid.UUID) P
-	NEQ func(uuid.UUID) P
+	EQ    func(uuid.UUID) P
+	NEQ   func(uuid.UUID) P
+	In    func(...uuid.UUID) P
+	NotIn func(...uuid.UUID) P
 }
 
 func (f FIQLUUID[P]) apply(op FIQLOp, val string) (P, error) {
 	var zero P
+	if op == In || op == NotIn {
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		us := make([]uuid.UUID, len(parts))
+		for i, s := range parts {
+			u, err := uuid.Parse(s)
+			if err != nil {
+				return zero, fmt.Errorf("invalid UUID value %q in list: %w", s, err)
+			}
+			us[i] = u
+		}
+		if op == In {
+			if f.In == nil {
+				return zero, fmt.Errorf("operator =in= not allowed on this UUID field")
+			}
+			return f.In(us...), nil
+		}
+		if f.NotIn == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this UUID field")
+		}
+		return f.NotIn(us...), nil
+	}
 	u, err := uuid.Parse(val)
 	if err != nil {
 		return zero, fmt.Errorf("invalid UUID value %q: %w", val, err)
@@ -335,8 +439,48 @@ func (f FIQLEnum[P]) apply(op FIQLOp, val string) (P, error) {
 			return zero, fmt.Errorf("unknown enum value %q — valid: %s", val, sortedMapKeys(f.NEQ))
 		}
 		return p, nil
+	case In:
+		if f.EQ == nil {
+			return zero, fmt.Errorf("operator =in= not allowed on this enum field (requires == annotation)")
+		}
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		preds := make([]P, len(parts))
+		for i, v := range parts {
+			p, ok := f.EQ[v]
+			if !ok {
+				return zero, fmt.Errorf("unknown enum value %q in list — valid: %s", v, sortedMapKeys(f.EQ))
+			}
+			preds[i] = p
+		}
+		if len(preds) == 1 {
+			return preds[0], nil
+		}
+		return orPreds(preds...), nil
+	case NotIn:
+		if f.NEQ == nil {
+			return zero, fmt.Errorf("operator =out= not allowed on this enum field (requires != annotation)")
+		}
+		parts, err := parseInListValue(val)
+		if err != nil {
+			return zero, err
+		}
+		preds := make([]P, len(parts))
+		for i, v := range parts {
+			p, ok := f.NEQ[v]
+			if !ok {
+				return zero, fmt.Errorf("unknown enum value %q in list — valid: %s", v, sortedMapKeys(f.NEQ))
+			}
+			preds[i] = p
+		}
+		if len(preds) == 1 {
+			return preds[0], nil
+		}
+		return andPreds(preds...), nil
 	default:
-		return zero, fmt.Errorf("operator %q not allowed on enum field — only == and != are supported", op)
+		return zero, fmt.Errorf("operator %q not allowed on enum field — only ==, !=, =in=, =out= are supported", op)
 	}
 }
 
@@ -374,6 +518,10 @@ func ParseFIQL[P Predicate](expr string, fields FIQLFields[P]) (P, error) {
 // maxFIQLDepth is the maximum nesting depth for parenthesised groups.
 // Prevents stack overflow on maliciously crafted expressions.
 const maxFIQLDepth = 50
+
+// maxFIQLListValues is the maximum number of values in a single =in= or =out=
+// list. Bounds parse cost and downstream SQL planner cost on hostile input.
+const maxFIQLListValues = 100
 
 // fiqlParser is a recursive descent FIQL parser.
 type fiqlParser[P Predicate] struct {
@@ -477,9 +625,17 @@ func (p *fiqlParser[P]) parseComparison() (P, error) {
 		return zero, err
 	}
 
-	value := p.readValue()
-	if value == "" {
-		return zero, fmt.Errorf("empty value for field %q at position %d", selector, p.pos)
+	var value string
+	if op == In || op == NotIn {
+		value, err = p.readListValue()
+		if err != nil {
+			return zero, err
+		}
+	} else {
+		value = p.readValue()
+		if value == "" {
+			return zero, fmt.Errorf("empty value for field %q at position %d", selector, p.pos)
+		}
 	}
 
 	fieldDesc, ok := p.fields[selector]
@@ -528,7 +684,7 @@ func (p *fiqlParser[P]) readOp() (FIQLOp, error) {
 		opStr := FIQLOp(p.expr[p.pos : p.pos+1+end+1])
 		p.pos += len(opStr)
 		switch opStr {
-		case GT, LT, GTE, LTE, Contains, HasPrefix:
+		case GT, LT, GTE, LTE, Contains, HasPrefix, In, NotIn:
 			return opStr, nil
 		default:
 			return "", fmt.Errorf("unknown operator %q at position %d", opStr, p.pos-len(opStr))
@@ -547,6 +703,43 @@ func (p *fiqlParser[P]) readValue() string {
 		p.pos++
 	}
 	return p.expr[start:p.pos]
+}
+
+// readListValue reads a parenthesised value list for =in= / =out= operators.
+// Returns the substring including the enclosing parens (e.g. "(a,b,c)").
+// Per-type apply methods strip the parens and split on ',' — see parseInListValue.
+func (p *fiqlParser[P]) readListValue() (string, error) {
+	if p.pos >= len(p.expr) || p.expr[p.pos] != '(' {
+		return "", fmt.Errorf("expected '(' after =in=/=out= operator at position %d", p.pos)
+	}
+	start := p.pos
+	p.pos++ // consume '('
+	for p.pos < len(p.expr) && p.expr[p.pos] != ')' {
+		p.pos++
+	}
+	if p.pos >= len(p.expr) {
+		return "", fmt.Errorf("unterminated list value starting at position %d", start)
+	}
+	p.pos++ // consume ')'
+	return p.expr[start:p.pos], nil
+}
+
+// parseInListValue strips the enclosing parens from a =in= / =out= value,
+// splits on ',', and enforces maxFIQLListValues. Returns the per-element
+// raw strings; per-type callers parse each element with their own parser.
+func parseInListValue(val string) ([]string, error) {
+	if len(val) < 2 || val[0] != '(' || val[len(val)-1] != ')' {
+		return nil, fmt.Errorf("malformed list value %q (expected (a,b,c))", val)
+	}
+	inner := val[1 : len(val)-1]
+	if inner == "" {
+		return nil, fmt.Errorf("empty value list for =in=/=out= operator")
+	}
+	parts := strings.Split(inner, ",")
+	if len(parts) > maxFIQLListValues {
+		return nil, fmt.Errorf("list value exceeds maximum of %d entries", maxFIQLListValues)
+	}
+	return parts, nil
 }
 
 // andPreds combines multiple predicates with AND.

--- a/fiql_test.go
+++ b/fiql_test.go
@@ -331,6 +331,192 @@ func TestParseFIQL_UUIDField(t *testing.T) {
 	})
 }
 
+func TestParseFIQL_StringIn(t *testing.T) {
+	var got []string
+	fields := entdomain.FIQLFields[testPred]{
+		"name": entdomain.FIQLString[testPred]{
+			In:    func(vs ...string) testPred { return testPred(func(s *sql.Selector) { got = append([]string(nil), vs...) }) },
+			NotIn: func(vs ...string) testPred { return testPred(func(s *sql.Selector) { got = append([]string{"not"}, vs...) }) },
+		},
+	}
+
+	t.Run("=in= happy path", func(t *testing.T) {
+		got = nil
+		pred, err := entdomain.ParseFIQL("name=in=(alice,bob,carol)", fields)
+		require.NoError(t, err)
+		pred(nil)
+		assert.Equal(t, []string{"alice", "bob", "carol"}, got)
+	})
+
+	t.Run("=out= happy path", func(t *testing.T) {
+		got = nil
+		pred, err := entdomain.ParseFIQL("name=out=(alice,bob)", fields)
+		require.NoError(t, err)
+		pred(nil)
+		assert.Equal(t, []string{"not", "alice", "bob"}, got)
+	})
+
+	t.Run("missing opening paren", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("name=in=alice,bob", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected '('")
+	})
+
+	t.Run("unterminated list", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("name=in=(alice,bob", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unterminated list")
+	})
+
+	t.Run("empty list rejected", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("name=in=()", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty value list")
+	})
+
+	t.Run("cap exceeded", func(t *testing.T) {
+		vs := make([]string, 0, 101)
+		for i := 0; i <= 100; i++ {
+			vs = append(vs, fmt.Sprintf("v%d", i))
+		}
+		expr := "name=in=(" + strings.Join(vs, ",") + ")"
+		_, err := entdomain.ParseFIQL(expr, fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum of 100")
+	})
+}
+
+func TestParseFIQL_IntIn(t *testing.T) {
+	var got []int
+	fields := entdomain.FIQLFields[testPred]{
+		"score": entdomain.FIQLInt[testPred]{
+			In: func(vs ...int) testPred { return testPred(func(s *sql.Selector) { got = append([]int(nil), vs...) }) },
+		},
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		got = nil
+		pred, err := entdomain.ParseFIQL("score=in=(10,20,30)", fields)
+		require.NoError(t, err)
+		pred(nil)
+		assert.Equal(t, []int{10, 20, 30}, got)
+	})
+
+	t.Run("invalid element", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("score=in=(10,abc,30)", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid integer value "abc" in list`)
+	})
+}
+
+func TestParseFIQL_FloatIn(t *testing.T) {
+	var got []float64
+	fields := entdomain.FIQLFields[testPred]{
+		"ratio": entdomain.FIQLFloat[testPred]{
+			In: func(vs ...float64) testPred { return testPred(func(s *sql.Selector) { got = append([]float64(nil), vs...) }) },
+		},
+	}
+	pred, err := entdomain.ParseFIQL("ratio=in=(1.5,2.5,3.5)", fields)
+	require.NoError(t, err)
+	pred(nil)
+	assert.Equal(t, []float64{1.5, 2.5, 3.5}, got)
+}
+
+func TestParseFIQL_UUIDIn(t *testing.T) {
+	a := "550e8400-e29b-41d4-a716-446655440000"
+	b := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	var got []uuid.UUID
+	fields := entdomain.FIQLFields[testPred]{
+		"id": entdomain.FIQLUUID[testPred]{
+			In: func(vs ...uuid.UUID) testPred { return testPred(func(s *sql.Selector) { got = append([]uuid.UUID(nil), vs...) }) },
+		},
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		got = nil
+		pred, err := entdomain.ParseFIQL("id=in=("+a+","+b+")", fields)
+		require.NoError(t, err)
+		pred(nil)
+		assert.Equal(t, []uuid.UUID{uuid.MustParse(a), uuid.MustParse(b)}, got)
+	})
+
+	t.Run("invalid uuid in list", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("id=in=("+a+",not-a-uuid)", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid UUID value "not-a-uuid" in list`)
+	})
+}
+
+func TestParseFIQL_EnumIn(t *testing.T) {
+	var calls []string
+	mkPred := func(tag string) testPred {
+		return testPred(func(s *sql.Selector) { calls = append(calls, tag) })
+	}
+	fields := entdomain.FIQLFields[testPred]{
+		"status": entdomain.FIQLEnum[testPred]{
+			EQ:  map[string]testPred{"active": mkPred("eq:active"), "inactive": mkPred("eq:inactive")},
+			NEQ: map[string]testPred{"active": mkPred("neq:active"), "inactive": mkPred("neq:inactive")},
+		},
+	}
+
+	t.Run("=in= composes OR of EQ entries", func(t *testing.T) {
+		calls = nil
+		pred, err := entdomain.ParseFIQL("status=in=(active,inactive)", fields)
+		require.NoError(t, err)
+		pred(sql.Dialect("sqlite3").Select("*").From(sql.Table("t")))
+		assert.ElementsMatch(t, []string{"eq:active", "eq:inactive"}, calls)
+	})
+
+	t.Run("=out= composes AND of NEQ entries", func(t *testing.T) {
+		calls = nil
+		pred, err := entdomain.ParseFIQL("status=out=(active,inactive)", fields)
+		require.NoError(t, err)
+		pred(sql.Dialect("sqlite3").Select("*").From(sql.Table("t")))
+		assert.ElementsMatch(t, []string{"neq:active", "neq:inactive"}, calls)
+	})
+
+	t.Run("unknown enum value in list", func(t *testing.T) {
+		_, err := entdomain.ParseFIQL("status=in=(active,pending)", fields)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown enum value "pending" in list`)
+	})
+}
+
+func TestParseFIQL_BoolRejectsIn(t *testing.T) {
+	fields := entdomain.FIQLFields[testPred]{
+		"active": entdomain.FIQLBool[testPred]{
+			EQ: func(v bool) testPred { return testPred(func(s *sql.Selector) {}) },
+		},
+	}
+	_, err := entdomain.ParseFIQL("active=in=(true,false)", fields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only == is supported")
+}
+
+func TestParseFIQL_GroupingPathUntouched(t *testing.T) {
+	// Regression: confirm the (expr) grouping path still works after
+	// adding =in= / =out= and the readListValue dispatch.
+	var calls []string
+	record := func(tag string) testPred {
+		return testPred(func(s *sql.Selector) { calls = append(calls, tag) })
+	}
+	fields := entdomain.FIQLFields[testPred]{
+		"name": entdomain.FIQLString[testPred]{
+			EQ: func(v string) testPred { return record("name=" + v) },
+		},
+		"score": entdomain.FIQLInt[testPred]{
+			GT: func(v int) testPred { return record(fmt.Sprintf("score>%d", v)) },
+		},
+	}
+
+	pred, err := entdomain.ParseFIQL("(name==a,name==b);score=gt=10", fields)
+	require.NoError(t, err)
+	pred(sql.Dialect("sqlite3").Select("*").From(sql.Table("t")))
+	assert.Contains(t, calls, "name=a")
+	assert.Contains(t, calls, "name=b")
+	assert.Contains(t, calls, "score>10")
+}
+
 func TestParseFIQL_StringHasPrefix(t *testing.T) {
 	var got string
 	fields := entdomain.FIQLFields[testPred]{

--- a/jobs/ENTD-002-FIQL-set-membership.md
+++ b/jobs/ENTD-002-FIQL-set-membership.md
@@ -1,0 +1,213 @@
+# ENTD-002-FIQL: Set membership operators (`=in=` / `=out=`)
+
+| Field      | Value                                                  |
+|------------|--------------------------------------------------------|
+| Status     | Done                                                   |
+| Created    | 2026-04-19                                             |
+| Assignee   | danhtran94                                             |
+| Source     | [scope-fiql-set-membership](../docs/scope-fiql-set-membership.md) |
+| Blocked by | —                                                      |
+
+## Goal
+Wire FIQL `=in=` (set membership) and `=out=` (set exclusion) end-to-end. Adds two operator constants, a parenthesised-list value reader (`readListValue`) gated to those operators only, `In`/`NotIn` slots on every set-supporting runtime field type (`FIQLString`/`Int`/`Float`/`UUID`), enum membership built from the existing EQ/NEQ maps at apply time, a 100-element list cap, and template emission via two new operator branches in the existing `FIQL{{kind}}` else-branch. Bool and time stay rejected; the parser's existing grouping path is untouched.
+
+## Problem
+
+    Current (verbose):
+      status==open,status==pending,status==closed                ← chained OR-EQ
+      status!=open;status!=pending;status!=closed                ← chained AND-NEQ
+
+    Want (FIQL standard, what every REST client expects):
+      status=in=(open,pending,closed)
+      status=out=(open,closed)
+
+The blocker is the parser, not ent — `user.NameIn(vs ...string)` and `user.NameNotIn(...)` already exist for every typed field. `readValue` (`fiql.go:507-517`) stops on the first `,` or `)`, so the parenthesised list form is unparseable today.
+
+## Solution: dedicated list reader + variadic field slots
+
+    After fix:
+      parseComparison reads op
+        → if op is In/NotIn → readListValue (consumes (...) verbatim)
+        → otherwise         → readValue (unchanged)
+
+      apply(In, "(a,b,c)") on FIQLString:
+        → strip parens, split on ',', enforce cap, call f.In("a", "b", "c")
+        → ent emits SQL IN (?, ?, ?) ✓
+
+      apply(In, "(active,closed)") on FIQLEnum:
+        → look up each value in f.EQ map → orPreds(p1, p2, ...) ✓
+        → no new template wiring; apply-time composition
+
+### Components
+
+**Parser changes** in `fiql.go`:
+- Two new op constants: `In = "=in="`, `NotIn = "=out="`
+- `maxFIQLListValues = 100` constant (precedent: `maxFIQLDepth = 50`)
+- `readListValue() (string, error)` — consumes `(` to matching `)`, returns the literal substring including parens
+- `parseComparison` dispatches to `readListValue` when the op is In/NotIn
+
+**Runtime field types** in `fiql.go`:
+- `FIQLString[P]`, `FIQLInt[P]`, `FIQLFloat[P]`, `FIQLUUID[P]` each gain `In func(...T) P` and `NotIn func(...T) P`
+- Each `apply` method handles `In`/`NotIn` by stripping parens, splitting on `,`, parsing each element via the same per-type parser as `==`, enforcing `maxFIQLListValues`, then calling `f.In(parsed...)` / `f.NotIn(parsed...)`
+- `FIQLEnum.apply` handles `In`/`NotIn` by looking up each value in the existing `EQ` (or `NEQ`) map and combining via `orPreds` (or `andPreds` for `=out=`); no new struct fields required
+- `FIQLBool.apply` explicitly rejects `In`/`NotIn` with the existing "operator not allowed on bool field" error shape
+
+**Template changes** in `template/fiql.tmpl`:
+- Add two new `{{- if eq $op }}` branches to the else-branch (`fiql.tmpl:54-83`):
+  - `=in=` → `In: {{ lower $n.Name }}.{{ $f.StructField }}In,`
+  - `=out=` → `NotIn: {{ lower $n.Name }}.{{ $f.StructField }}NotIn,`
+- Enum branch (`fiql.tmpl:36-53`) stays unchanged — set membership is built at apply time from the existing maps
+
+### Why not alternatives
+
+| Approach | Verdict |
+|---|---|
+| **`=in=(a,b,c)` standard syntax + parser dispatch on op** | Chosen. FIQL-standard, clearly bounded parser change, every type uses ent's native `FieldIn`. |
+| Pipe-separated values (`=in=a\|b\|c`) | Rejected. Non-standard; breaks any value containing `\|`; gains nothing — parser change is needed either way for the cap enforcement. |
+| Reuse OR-of-EQ at template level (no new operators) | Rejected. Already works today via chained `==`; fails to match the FIQL spec; doesn't produce SQL `IN (...)` for typed fields. |
+| Per-type variadic struct fields with type-parameterised `FIQLEnum[P, E]` | Rejected. Adding a second type parameter to FIQLEnum breaks the public API; OR-of-EQ at apply time is functionally identical and SQL-equivalent on every supported engine. |
+
+## Workstreams
+
+### 1. Operator constants & parser
+
+Foundational — adds the two op constants, the cap constant, the list-value reader, and the dispatch in `parseComparison`. Unblocks every other workstream.
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1.1 | Add `In = "=in="` and `NotIn = "=out="` to the `FIQLOp` constant block | `fiql.go` | [x] |
+| 1.2 | Add `maxFIQLListValues = 100` constant near `maxFIQLDepth` | `fiql.go` | [x] |
+| 1.3 | Add `readListValue() (string, error)` — consumes `(...)` from current pos, returns substring including parens; errors on missing `(`, missing `)`, or empty list `()` | `fiql.go` | [x] |
+| 1.4 | Update `parseComparison` to call `readListValue` when op is `In`/`NotIn`, otherwise `readValue` (unchanged path for all other ops) | `fiql.go` | [x] |
+| 1.5 | Update `readOp` switch to recognise `=in=` and `=out=` alongside the existing extended ops | `fiql.go` | [x] |
+
+**Key details:** `readListValue` returns the value WITH parens (e.g. `"(a,b,c)"`). The per-type `apply` strips them. Empty list error wording: `empty value list for =in= operator at position N`. Cap exceeded error wording: `=in= list exceeds maximum of 100 values at position N`. Both errors wrap the failing position so callers can locate the bad term.
+
+### 2. Runtime field-type slots and apply dispatch
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 2.1 | Add `In func(...string) P` and `NotIn func(...string) P` to `FIQLString[P]`; extend `apply` to strip parens, split, enforce cap, call `f.In(parts...)` / `f.NotIn(parts...)` | `fiql.go` | [x] |
+| 2.2 | Add analogous `In`/`NotIn` to `FIQLInt[P]`; extend `apply` (parse each via `strconv.Atoi`, error on first bad element with element value named) | `fiql.go` | [x] |
+| 2.3 | Add analogous `In`/`NotIn` to `FIQLFloat[P]`; extend `apply` (parse via `strconv.ParseFloat`) | `fiql.go` | [x] |
+| 2.4 | Add analogous `In`/`NotIn` to `FIQLUUID[P]`; extend `apply` (parse via `uuid.Parse`) | `fiql.go` | [x] |
+| 2.5 | Extend `FIQLEnum.apply` to handle `In`/`NotIn` by looking up each value in the existing `EQ`/`NEQ` map and combining via `orPreds`/`andPreds`; no new struct fields | `fiql.go` | [x] |
+| 2.6 | Confirm `FIQLBool.apply` rejects `In`/`NotIn` with the existing default-case error (no code change expected; verify) | `fiql.go` | [x] |
+
+**Key details:** Factor the parse-list-value helper once. Sketch:
+
+```go
+func parseInListValue(val string, max int) ([]string, error) {
+    if len(val) < 2 || val[0] != '(' || val[len(val)-1] != ')' {
+        return nil, fmt.Errorf("malformed list value %q (expected (a,b,c))", val)
+    }
+    inner := val[1 : len(val)-1]
+    if inner == "" {
+        return nil, fmt.Errorf("empty value list")
+    }
+    parts := strings.Split(inner, ",")
+    if len(parts) > max {
+        return nil, fmt.Errorf("list exceeds maximum of %d values", max)
+    }
+    return parts, nil
+}
+```
+
+Each typed `apply` calls this then maps via the per-type parser. Enum reuses it but maps via the EQ/NEQ map lookup with the same "unknown enum value" error wording the existing code produces.
+
+### 3. Generator template
+
+Wire emission so annotated `In`/`NotIn` ops produce `In: x.FieldIn` / `NotIn: x.FieldNotIn` lines.
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 3.1 | Add two new `{{- if eq $op "=in=" }}` / `{{- if eq $op "=out=" }}` blocks to `template/fiql.tmpl` else-branch (lines 54-83) | `template/fiql.tmpl` | [x] |
+| 3.2 | Verify enum branch (lines 36-53) needs no template edit — set membership is apply-time | `template/fiql.tmpl` | [x] |
+
+**Key details:** The else-branch emits `entdomain.FIQL{{ $kind }}[predicate.X]{ ...op fields... }`. Two new lines to add, mirroring the existing `EQ`/`NEQ` shape. Enum stays as-is because `FIQLEnum` keeps the same `EQ`/`NEQ` map fields and dispatches `In`/`NotIn` at apply time.
+
+### 4. Example schema annotations
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 4.1 | Extend `score` field annotation to include `entdomain.In, entdomain.NotIn` | `examples/basic/ent/schema/user.go` | [x] |
+| 4.2 | Extend `status` field annotation to include `entdomain.In, entdomain.NotIn` | `examples/basic/ent/schema/user.go` | [x] |
+
+### 5. Codegen
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 5.1 | `make gen-basic` — confirm `examples/basic/ent/fiql.go` shows `In: user.ScoreIn, NotIn: user.ScoreNotIn` for score; status entry unchanged structurally (still `EQ`/`NEQ` maps) | `examples/basic/ent/fiql.go` (output) | [x] |
+| 5.2 | `make gen` — second run shows zero diff | all generated outputs | [x] |
+
+### 6. Testing
+
+| # | Task | Status |
+|---|------|--------|
+| 6.1 | Parser unit tests in `fiql_test.go`: `readListValue` happy path, missing `(`, missing `)`, empty `()`, cap exceeded (101 values) | [x] |
+| 6.2 | Runtime unit tests in `fiql_test.go`: `FIQLString.apply(In, ...)` with valid list, invalid element, exceeds cap; same for `FIQLInt`, `FIQLFloat`, `FIQLUUID`, `FIQLEnum` (including unknown-enum-value error) | [x] |
+| 6.3 | Runtime unit test: `FIQLBool.apply(In, ...)` returns the operator-not-allowed error | [x] |
+| 6.4 | Regression test in `fiql_test.go`: `(name==a,name==b)` still parses as grouped-OR (proves parser grouping path is untouched) | [x] |
+| 6.5 | Integration tests in `examples/basic/ent/fiql_test.go`: `score=in=(10,20,30)` produces SQL containing `IN (?`; `score=out=(10,20)` produces `NOT IN (?`; `status=in=(active,inactive)` produces `OR`-joined EQ; `status=out=(active)` produces NEQ; empty `()` and bad-value error paths | [x] |
+
+### 7. Documentation
+
+| # | Task | Status |
+|---|------|--------|
+| 7.1 | README Operator Constants table — add `In` (`=in=`) and `NotIn` (`=out=`) rows; "Valid for" lists string, int, float, enum, uuid (excludes bool, time) | [x] |
+| 7.2 | README FIQL syntax block (~L324) — add the `field=in=(a,b,c)` and `field=out=(a,b,c)` syntax lines | [x] |
+| 7.3 | README Generated Code example (~L370) — show `In: user.ScoreIn, NotIn: user.ScoreNotIn` on the `score` line | [x] |
+| 7.4 | README Known Limitations — add: (a) bool and time fields don't support set membership; (b) values containing `,` or `)` cannot be used in lists (use chained `==` for those); (c) max 100 elements per list | [x] |
+
+## Design Decisions
+
+### `=in=(a,b,c)` standard syntax over a non-standard separator
+FIQL spec compliance is the goal. The parser change is contained (one new helper, one dispatch site) and reusing the standard form means existing FIQL clients work without translation.
+
+### Hard 100-element cap, not configurable
+Default that bounds parse cost and SQL planner cost without user friction for typical filters. Configurability is a clean follow-up if a real user need surfaces; preemptively exposing knobs invites footguns.
+
+### Empty `()` is a parse error, not "always-false"
+Silent always-false hides upstream bugs (CSV import with zero rows shouldn't silently match nothing — it should fail loudly). Loud parse error is the safer default.
+
+### Enum set membership composed from existing EQ/NEQ maps
+Avoids adding a second type parameter to `FIQLEnum` or duplicating the enum→typed-value mapping. SQL plan difference (OR-of-EQ vs. `IN`) is collapsed by every supported DB engine.
+
+## What Stays Unchanged
+- `parseAtom`'s grouping path (`fiql.go:412-432`) — `(expr)` for sub-expression grouping is reachable only outside a comparison context; the new `readListValue` is reachable only after an `In`/`NotIn` operator
+- `readValue` (`fiql.go:507-517`) — used for every other op, no behavior change
+- `FIQLEnum` struct shape — no new fields; new behavior in apply only
+- `FIQLBool` — no new fields, no apply change beyond verifying the existing default-case rejection works for `In`/`NotIn`
+- `examples/custom` — no annotation changes; will pick up the runtime types when imported
+- Proto generation pipeline — unrelated; untouched
+
+## Implementation Order
+
+    1. WS1: parser & op constants    ← unblocks WS2, WS3, WS6
+    2. WS2: runtime types            ← depends on WS1 (op constants)
+    3. WS3: template                 ← depends on WS2 (slot fields exist)
+    4. WS4: schema annotations       ← depends on WS1 (op constants)
+    5. WS5: regenerate               ← depends on WS1+WS2+WS3+WS4
+    6. WS6: tests                    ← parser unit (after WS1), runtime unit (after WS2), integration (after WS5)
+    7. WS7: README                   ← last; after behavior is verified
+
+## Notes
+- Reuses existing `orPreds` / `andPreds` helpers (`fiql.go:519-527`)
+- `github.com/google/uuid` already imported (from ENTD-001)
+- `make gen` is the CI gate — must produce zero diff after a clean rerun
+- Verification cadence: `go build ./...` + `make test` after every code edit; `make gen` after WS4
+- Watch for parser regressions on grouped expressions — the dedicated regression test (WS6.4) is the canary
+
+## Discoveries & Decisions During Implementation
+(Filled during execution — never during planning)
+
+### [Implementer] FIQLBool.apply parsed value before checking op — needed reordering
+The original `FIQLBool.apply` (`fiql.go:341-354`) called `strconv.ParseBool(val)` first, then validated the operator. With `=in=(true,false)` as input, ParseBool would fail with "invalid bool value", masking the real error (`=in=` is unsupported on bool). Fixed by moving the op check ahead of the parse so the rejection error is reachable. Same hazard exists in `FIQLInt`/`Float`/`UUID`/`Time` apply methods — they parse first too — but for those, the In/NotIn handling is added as a top-level branch BEFORE the parse, so the issue doesn't surface. Worth knowing for any future "this op is unsupported on this type" diagnostic: it has to fire before any value-parsing code.
+
+### [Implementer] `pred(nil)` panics through `andPreds`/`orPreds`
+The grouping regression test (WS6.4) initially called `pred(nil)` like the simple-EQ tests do. That works for a single predicate function but panics inside `sql.AndPredicates`/`OrPredicates` because they call methods on the selector. Fixed by passing a real `sql.Dialect("sqlite3").Select(...)` selector. Lesson: any test that builds a composite predicate (AND/OR) cannot use `nil` as the selector — give it a real one. The simple-record-via-side-effect pattern only works with single-predicate paths.
+
+### [Implementer] Enum struct shape unchanged — apply-time composition validates the design
+The scope decision to skip new `FIQLEnum` struct fields and compose set membership from existing `EQ`/`NEQ` maps proved correct in practice: the template needed zero changes for enums, the regenerated `examples/basic/ent/fiql.go` `status` entry stayed structurally identical, and the SQL output is the standard OR-of-EQ pattern that the planner collapses to an IN scan. No type-parameter expansion of `FIQLEnum` was needed. Confirmed by direct integration test (`TestUserFIQL_EnumIn`).
+
+<!-- approved -->

--- a/template/fiql.tmpl
+++ b/template/fiql.tmpl
@@ -78,6 +78,12 @@ var {{ $n.Name }}FIQLFields = entdomain.FIQLFields[predicate.{{ $n.Name }}]{
         {{- if eq $op "=prefix=" }}
         HasPrefix: {{ lower $n.Name }}.{{ $f.StructField }}HasPrefix,
         {{- end }}
+        {{- if eq $op "=in=" }}
+        In: {{ lower $n.Name }}.{{ $f.StructField }}In,
+        {{- end }}
+        {{- if eq $op "=out=" }}
+        NotIn: {{ lower $n.Name }}.{{ $f.StructField }}NotIn,
+        {{- end }}
         {{- end }}
     },
     {{- end }}


### PR DESCRIPTION
## What
Adds two FIQL operators for set membership: `=in=` (value in list) and `=out=` (value not in list), following the FIQL standard syntax `field=in=(a,b,c)`. Supported on string, int, float, enum, and uuid; bool and time intentionally rejected (`=in=(true,false)` is meaningless; time uses range operators).

## Why
- Source scope: [`docs/scope-fiql-set-membership.md`](docs/scope-fiql-set-membership.md)
- Job doc:     [`jobs/ENTD-002-FIQL-set-membership.md`](jobs/ENTD-002-FIQL-set-membership.md)

Today's workaround is verbose chained EQ/NEQ (`status==open,status==pending,status==closed`). It scales linearly, doesn't produce SQL `IN (...)` for typed fields, and doesn't match what FIQL clients expect. ent already has `FieldIn`/`FieldNotIn` predicates for every typed field — the blocker was solely the parser, which stopped values at `,` and `)`.

## How to test
```sh
make build
make test
make gen && git diff --exit-code   # zero diff after regen
```

Concrete `=in= / =out=` exercises:
```sh
go test -run "TestUserFIQL_(IntIn|IntNotIn|EnumIn|EnumNotIn|InEmptyList|InBadElement)" -v ./examples/basic/ent/...
go test -run "TestParseFIQL_(StringIn|IntIn|FloatIn|UUIDIn|EnumIn|BoolRejectsIn|GroupingPathUntouched)$" -v .
```

## Notes
- **Template touched twice** — only the typed-field else-branch (`template/fiql.tmpl:78-86`) gains two new `{{ if eq $op }}` blocks for `=in=` / `=out=`. Enum branch is untouched; set membership for enums composes OR-of-EQ at apply time from the existing `EQ`/`NEQ` maps. No second type parameter on `FIQLEnum`.
- **Hard cap of 100 values per list** — bounds parse cost and SQL planner cost. Documented in README Known Limitations.
- **Empty `()` is a parse error**, not always-false — louder default that surfaces upstream caller bugs.
- **Grouping path untouched** — `(expr)` for sub-expressions still works; the new `readListValue` is reachable only after an `In`/`NotIn` operator. Explicit regression test asserts this.
- **`FIQLBool.apply` reordered** — checks op before parsing so the unsupported-on-bool error fires for `=in=`. Same diagnostic guarantee for any future "this op is unsupported on this type" check.

## Checklist
- [x] Tests added (7 new runtime test functions, 6 new integration tests, 1 grouping regression)
- [x] `make gen` run; second run shows zero diff
- [x] No new ADR/RFC required (scope note captures the design)
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FIQL set-membership operators `=in=` and `=out=` to filter by multiple values (strings, ints, floats, UUIDs, enums).

* **Documentation**
  * Extended docs and README with operator syntax, supported types, and limitations (not supported for bool/time, max 100 list values, parsing limits with commas/parentheses).

* **Tests**
  * Added parser and runtime tests covering success and error cases for list-based operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->