### PR TITLE
chore(ci): disable CodeRabbit bot-PR trigger, keep as reference

### DIFF
--- a/.github/workflows/coderabbit-bot-prs.yml
+++ b/.github/workflows/coderabbit-bot-prs.yml
@@ -1,14 +1,34 @@
 name: Trigger CodeRabbit review on bot PRs
 
-# CodeRabbit skips bot-authored PRs (renovate[bot], dependabot[bot]) by default;
-# the skip is hardcoded server-side and not overridable via .coderabbit.yaml.
-# This workflow posts a `@coderabbitai review` comment on bot PRs so they get
-# reviewed anyway — important for dependency updates where supply-chain risk
-# benefits from a second pair of eyes.
+# DISABLED — preserved as a reference pattern, not as a working trigger.
+#
+# Intent: CodeRabbit skips bot-authored PRs (renovate[bot], dependabot[bot]) by
+# default; the skip is hardcoded server-side and not overridable via
+# .coderabbit.yaml. This workflow posted a `@coderabbitai review` comment on bot
+# PRs so they got reviewed anyway — valuable for dependency updates where
+# supply-chain risk benefits from a second pair of eyes.
+#
+# Why it never worked: CodeRabbit ignores commands issued by bot accounts (loop
+# prevention). Comments created with GITHUB_TOKEN are authored by
+# `github-actions[bot]`, so every ping this workflow posted was dropped. Measured
+# across all 11 bot PRs from 2026-04-30 to 2026-07-25:
+#
+#   github-actions[bot] posts `@coderabbitai review`  ->  0/11 responses
+#   danhtran94 posts the same comment by hand         ->  11/11, within 4-11s
+#
+# Reviving it requires the comment to come from a non-bot identity: swap
+# GITHUB_TOKEN for a fine-grained PAT (repo-scoped, `pull-requests: write`) held
+# as a repo secret, and pass it to github-script via `github-token`. Until then
+# the trigger is manual — comment `@coderabbitai review` on the PR yourself.
+#
+# The `pull_request_target` trigger is deliberately removed rather than left
+# guarded: it grants a base-repo write token in the context of an external PR,
+# and carrying that surface for a no-op is not worth it. `workflow_dispatch`
+# keeps the file valid without any automatic entry point. The `if:` guard below
+# evaluates false under dispatch, so the job stays inert by design.
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## What

Disables the `Trigger CodeRabbit review on bot PRs` workflow while keeping the file as a reference pattern. Swaps `pull_request_target` for `workflow_dispatch` and records in a header comment why the mechanism never worked and what reviving it would take.

## Why

The workflow has never produced a single CodeRabbit review. CodeRabbit ignores commands issued by bot accounts (loop prevention), and comments created with `GITHUB_TOKEN` are authored by `github-actions[bot]` — so every ping it posted was silently dropped.

Measured across all 11 bot PRs from 2026-04-30 to 2026-07-25:

| Comment author | CodeRabbit response |
|---|---|
| `github-actions[bot]` (this workflow) | **0/11** |
| `danhtran94` (by hand) | **11/11, within 4–11s** |

Every bot PR that actually got reviewed was triggered manually, days after opening. Example — #37: workflow pinged at `2026-05-24T17:57:53Z` and got nothing; a manual comment on `05-28T18:22:21Z` drew an ack in 6 seconds and an approval 2.5 minutes later.

Two deliberate choices:

- **Kept the file, not deleted.** The idempotent comment-posting pattern is worth referencing, and a fine-grained PAT (repo-scoped, `pull-requests: write`) passed to `github-script` via `github-token` would revive it.
- **Removed `pull_request_target` rather than guarding the job.** It grants a base-repo write token in the context of an external PR — the classic dangerous trigger. It was safe here only because nothing checks out PR code, and carrying that surface for a no-op isn't worth relying on nobody adding a checkout step later. `workflow_dispatch` keeps the file valid with no automatic entry point; the existing `if:` guard evaluates false under dispatch, so the job stays inert.

No impact on branch protection: required checks on `main` are `CodeQL`, `govulncheck`, `golangci-lint (gosec + staticcheck + gocritic)`, and `test`. The `trigger` job was never among them.

## How to test

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coderabbit-bot-prs.yml'))"` → parses, triggers reduce to `workflow_dispatch`
- `harness validate-pr-checklist` → passes
- Actions tab shows no `Trigger CodeRabbit review on bot PRs` run on new PRs

## Checklist

- [x] Tests added/updated — n/a, CI config only, no Go code touched
- [x] make gen run if schemas changed — n/a; gate confirmed generated code in sync
- [ ] ADR/RFC created if architectural decision involved — n/a
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
