### PR TITLE
chore(ci): pass SCORECARD_TOKEN so Branch-Protection is scored

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,6 +28,15 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # The default GITHUB_TOKEN cannot read classic branch protection
+          # rules, so Branch-Protection returns -1 (internal error) and drops
+          # out of the aggregate instead of being scored. SCORECARD_TOKEN is a
+          # fine-grained PAT scoped to this repo with `Administration: Read-only`
+          # (which implies `Metadata: Read-only`) — nothing else, no write.
+          # It expires after a year; renew it or Branch-Protection silently
+          # reverts to -1. Falls back to GITHUB_TOKEN when the secret is absent
+          # so the workflow keeps running rather than hard-failing.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
 
       - name: Upload Scorecard results to Security tab
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4


### PR DESCRIPTION
## What

Passes a fine-grained PAT to `ossf/scorecard-action` via `repo_token` so the `Branch-Protection` check can actually run. Falls back to `github.token` when the secret is absent.

## Why

The published Scorecard currently reports:

```
Branch-Protection: -1
internal error: error during branchesHandler.setup: internal error:
some github tokens can't read classic branch protection rules
```

A `-1` check is **excluded from the aggregate**, not counted as zero. So the headline **9.2** is an average over the checks that did run — the protection posture of `main` is not being measured at all. Fixing this is less about raising the score than about making it mean something.

`scorecard-action` can only read branch protection with a token carrying `Administration: Read-only`, which the default `GITHUB_TOKEN` does not have. Per the [scorecard-action fine-grained token docs](https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md), the required setup is a repo secret named `SCORECARD_TOKEN`.

⚠ **Expect the published score to drop, not rise.** `enforce_admins` is `false` on `main`, which `Branch-Protection` penalises. That is a real number replacing a missing one — the current 9.2 is flattering.

### Required before this has any effect

This PR is inert until the secret exists. Create it at `Settings → Secrets and variables → Actions`:

- Name: `SCORECARD_TOKEN`
- Value: a fine-grained PAT scoped to **this repository only**
- Repository permissions: **`Administration: Read-only`** (implies `Metadata: Read-only`). Nothing else — no write anywhere.

The token expires after one year; when it lapses, `Branch-Protection` silently reverts to `-1`. That caveat is recorded in a comment beside the input so it is visible at the point of use.

### Why the `||` fallback

`repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}` means merge order does not matter and a missing or expired secret degrades to exactly today's behaviour rather than hard-failing the workflow. Classic PATs with `repo` scope also work but grant far more than read access; the OpenSSF docs strongly discourage them.

## How to test

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"` → parses; `repo_token` resolves to the fallback expression
- `harness validate-pr-checklist` → passes
- After creating the secret and merging: rerun the workflow, then check `curl -s https://api.securityscorecards.dev/projects/github.com/danhtran94/entdomain | jq '.checks[] | select(.name=="Branch-Protection")'` → score is a real number, not `-1`

## Checklist

- [x] Tests added/updated — n/a, CI config only, no Go code touched
- [x] make gen run if schemas changed — n/a; gate confirmed generated code in sync
- [ ] ADR/RFC created if architectural decision involved — n/a
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scorecard checks by using an enhanced access token when available.
  * Added a fallback to the standard repository token so checks continue running without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->