### PR TITLE
fix: restore verbatim Apache-2.0 text so the license is detectable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -32,9 +33,10 @@
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
 
-      "Work" shall mean the work of authorship made available under
-      the License, as indicated by a copyright notice that is included in
-      or attached to the work (an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
@@ -44,21 +46,23 @@
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
 
-      "Contribution" shall mean, as submitted to the Licensor for inclusion
-      in the Work by the copyright owner or by an individual or Legal Entity
-      authorized to submit on behalf of the copyright owner. For the purposes
-      of this definition, "submit" means any form of electronic, verbal, or
-      written communication sent to the Licensor or its representatives,
-      including but not limited to communication on electronic mailing lists,
-      source code control systems, and issue tracking systems that are managed
-      by, or on behalf of, the Licensor for the purpose of developing and
-      improving the Work, but excluding communication that is conspicuously
-      marked or designated in writing by the copyright owner as "Not a
-      Contribution."
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any Legal Entity on behalf of
-      whom a Contribution has been received by the Licensor and included
-      within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
@@ -72,49 +76,57 @@
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       (except as stated in this section) patent license to make, have made,
       use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent contributions
-      Licensable by such Contributor that are necessarily infringed by
-      their Contribution(s) alone or by the combination of their
-      Contribution(s) with the Work to which such Contribution(s) was
-      submitted. If You institute patent litigation against any entity
-      (including a cross-claim or counterclaim in a lawsuit) alleging that
-      the Work or any Contribution embodied within the Work constitutes
-      direct or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate as of
-      the date such litigation is filed.
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-   4. Redistribution. You may reproduce and distribute copies of the Work
-      or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You meet
-      the following conditions:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-      (a) You must give any other recipients of the Work or Derivative Works
-          a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
 
-      (c) You must retain, in the Source form of any Derivative Works that
-          You distribute, all copyright, patent, trademark, and attribution
-          notices from the Source form of the Work, excluding those notices
-          that do not pertain to any part of the Derivative Works; and
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
       (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, You must include a readable copy of the attribution
-          notices contained within such NOTICE file, in all reasonable ways
-          upon redistribution, provided that such NOTICE file is not part of
-          the Derivative Works themselves.
-
-      You may add Your own attribution notices within Derivative Works that
-      You distribute, alongside or in addition to the NOTICE text from the
-      Work, provided that such additional attribution notices cannot be
-      construed as modifying the License.
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
       You may add Your own copyright statement to Your modifications and
-      may provide additional terms and conditions for use, reproduction,
-      or distribution of Your modifications, or for such Derivative Works
-      as a whole, provided Your use, reproduction, and distribution of the
-      Work otherwise complies with the conditions stated in this License.
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
@@ -133,10 +145,10 @@
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any implied warranties or
-      conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
-      FOR A PARTICULAR PURPOSE. You are solely responsible for determining
-      the appropriateness of using or reproducing the Work and assume any
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
 
    8. Limitation of Liability. In no event and under no legal theory,
@@ -144,17 +156,17 @@
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
       liable to You for damages, including any direct, indirect, special,
-      incidental, or exemplary damages of any character arising as a result
-      of this License or out of the use or inability to use the Work
-      (including but not limited to damages for loss of goodwill, work
-      stoppage, computer failure or malfunction, or all other commercial
-      damages or losses), even if such Contributor has been advised of the
-      possibility of such damages.
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer, and
-      charge a fee for, acceptance of support, warranty, indemnity, or
-      other liability obligations and/or rights consistent with this
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
       License. However, in accepting such obligations, You may act only
       on Your own behalf and on Your sole responsibility, not on behalf
       of any other Contributor, and only if You agree to indemnify,
@@ -172,7 +184,7 @@
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
       file or class name and description of purpose be included on the
-      same "printed line" as the copyright notice for easier
+      same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
    Copyright [yyyy] [name of copyright owner]


### PR DESCRIPTION
## What

Replaces `LICENSE` with the verbatim Apache-2.0 text from apache.org. The file on `main` is a **reworded** Apache-2.0, which no license scanner recognises.

## Why

Two independent tools currently fail to identify this module's license:

- **pkg.go.dev** shows `License: UNKNOWN` and fails its *Redistributable license* check
- **Scorecard** reports `project license file does not contain an FSF or OSI license` (License: 9/10)

Both use [`github.com/google/licensecheck`](https://pkg.go.dev/github.com/google/licensecheck), which matches license text and needs high coverage to claim a match. Measured directly against the file on `main`:

| File | Coverage | Matched region |
|---|---|---|
| `LICENSE` (before) | **6.74%** | bytes 9891–10568 only |
| `apache.org/licenses/LICENSE-2.0.txt` | **100%** | whole file |
| `LICENSE` (this PR) | **100%** | whole file |

The only region that matched was the trailing APPENDIX. The entire body — the actual grant of rights — was paraphrased rather than copied, so it did not match Apache-2.0 at all.

### This completes a repair already in progress

It does not reverse a deliberate decision. The history shows the file being fixed piecemeal:

| Commit | Effect |
|---|---|
| `90e443b` | Added a **reworded** Apache-2.0, not the real text |
| `0f715db` | Restored section 9 to canonical wording |
| `9e16cf6` | Restored the APPENDIX "for pkg.go.dev detection" |

`9e16cf6` is exactly why the tail was the only matching region. What remained reworded was the Definitions section — `"Work"`, `"Contribution"`, `"Contributor"` — and that is what held coverage at 6.74%.

Note that `0f715db`'s diff replaced *"You may offer only on behalf with the terms of this License"* with the canonical clause. The old wording was not a considered legal variant; it was broken text.

### Nothing custom was dropped

The only copyright line in the old file was the unmodified `Copyright [yyyy] [name of copyright owner]` placeholder from the appendix template. There is no NOTICE file and no named copyright holder to preserve.

⚠ Beyond tooling: a reworded Apache-2.0 **is not Apache-2.0**. For a library distributed via `go get`, downstream consumers running license scanners see an unknown license, and some corporate policies block unknown licenses outright.

## How to test

```
curl -sS https://www.apache.org/licenses/LICENSE-2.0.txt | diff - LICENSE   # no output
```

Coverage measured with a throwaway program calling `licensecheck.Scan` on the file — `100.00%`, single `Apache-2.0` match spanning bytes 0–11358.

After merge, pkg.go.dev re-indexes on the next module fetch; the license should resolve to `Apache-2.0` and the *Redistributable license* check should pass.

## Checklist

- [x] Tests added/updated — n/a, license text only, no Go code touched
- [x] make gen run if schemas changed — n/a; gate confirmed generated code in sync
- [ ] ADR/RFC created if architectural decision involved — n/a
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
