### PR TITLE
chore(renovate): group github-actions updates, majors separate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,16 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Go dependencies",
       "automerge": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "GitHub Actions (major)"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "GitHub Actions"
     }
   ],
   "timezone": "Asia/Ho_Chi_Minh",


### PR DESCRIPTION
## What

Groups `github-actions` updates into at most two PRs, with majors kept separate from digests.

This is the second half of #48. That PR was merged while its head was still `9bcd4b2`, so only the schedule change landed — the grouping commit never made it into the squash. This re-applies it on top of current `main`.

## Why

The `github-actions` manager has no `packageRule`, so Renovate falls back to one PR per action. On 2026-07-25 that produced **6 PRs in 40 seconds** (#38 #39 #40 #41 #43 #44), which exhausted the CodeRabbit free-tier review quota and left every PR that day unreviewed until the limit reset.

Two rules rather than one, so a major cannot block a digest:

| Rule | Today's batch would become |
|---|---|
| `GitHub Actions (major)` | `checkout v6→v7`, `setup-go v6→v7` |
| `GitHub Actions` | `codeql-action` digest, `scorecard-action v2.4.4` |

**6 PRs → 2.** The majors are the updates that can actually break CI; `codeql-action` digests ship weekly and rarely do. Grouping them together would let a broken major hold back the safest update in the set.

No built-in preset covers this: `group:githubArtifactActions` only targets `upload-artifact`/`download-artifact`, which this repo does not use, and `group:allNonMajor` excludes digests — which were 3 of the 6 PRs. Explicit rules are both narrower and more predictable.

The existing `gomod` rule is untouched, so Go dependencies keep their own group.

## How to test

- `python3 -c "import json; json.load(open('renovate.json'))"` → parses
- `npx --package renovate renovate-config-validator renovate.json` → `Config validated successfully against 1 file(s)`
- `harness validate-pr-checklist` → passes
- Rules resolve in order: `gomod minor/patch → Go dependencies`, `github-actions major → GitHub Actions (major)`, `github-actions minor/patch/digest → GitHub Actions`
- After merge: the next batch of action updates arrives as at most two grouped PRs

## Checklist

- [x] Tests added/updated — n/a, bot config only, no Go code touched
- [x] make gen run if schemas changed — n/a; gate confirmed generated code in sync
- [ ] ADR/RFC created if architectural decision involved — n/a
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
