### PR TITLE
docs: drop the retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Security](https://github.com/danhtran94/entdomain/actions/workflows/security.yml/badge.svg)](https://github.com/danhtran94/entdomain/actions/workflows/security.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/danhtran94/entdomain/badge)](https://scorecard.dev/viewer/?uri=github.com/danhtran94/entdomain)
 [![Go Reference](https://pkg.go.dev/badge/github.com/danhtran94/entdomain.svg)](https://pkg.go.dev/github.com/danhtran94/entdomain)
-[![Go Report Card](https://goreportcard.com/badge/github.com/danhtran94/entdomain)](https://goreportcard.com/report/github.com/danhtran94/entdomain)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 An [ent](https://entgo.io/ent) extension that generates a pure Go domain layer from your ent schema — with zero ORM dependency in the domain package.


### PR DESCRIPTION
## What

Removes the Go Report Card badge from `README.md`. One line deleted, nothing added.

## Why

[Go Report Card](https://goreportcard.com/) has been sunset after more than a decade of grading Go repositories.

The failure is quiet rather than obvious. Both endpoints still return HTTP 200:

```
https://goreportcard.com/badge/...   → HTTP 200
https://goreportcard.com/report/...  → HTTP 200
```

But the SVG it serves now reads:

```xml
<svg ... role="img" aria-label="go report: retired">
  <title>go report: retired</title>
  <rect x="63" width="55" height="20" fill="#9f9f9f"/>   <!-- grey -->
```

So the README displays a grey **`go report | retired`** badge, which scans as a *failing grade for this project* rather than a discontinued service. That is worse than having no badge.

### Nothing replaces it

The sunset notice points to **golangci-lint** as the successor — *"the de-facto standard for Go code quality today"*. This repo already runs it, with `gosec`, `staticcheck`, and `gocritic`, in the Security workflow. The existing Security badge already reports that job's status, so adding a second badge for the same workflow would be noise.

The remaining badges (CI, CodeRabbit, Security, OpenSSF Scorecard, Go Reference, License) are unaffected.

## How to test

- `grep -rn goreportcard README.md` → no matches
- `harness validate-pr-checklist` → passes
- Render the README on GitHub: no grey `retired` badge in the header row

## Checklist

- [x] Tests added/updated — n/a, README only, no Go code touched
- [x] make gen run if schemas changed — n/a; gate confirmed generated code in sync
- [ ] ADR/RFC created if architectural decision involved — n/a
- [x] AI-assisted: I understand the generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Go Report Card badge from the project README while preserving the other project status badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->